### PR TITLE
explore builders and how to use them

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
 members = [
   "crates/support",
-  "crates/configuration"
+  "crates/configuration",
 ]

--- a/crates/configuration/Cargo.toml
+++ b/crates/configuration/Cargo.toml
@@ -4,3 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.85"
+serde-wasm-bindgen = "0.5"
+thiserror = "1.0.40"

--- a/crates/configuration/src/errors.rs
+++ b/crates/configuration/src/errors.rs
@@ -1,0 +1,10 @@
+#[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
+pub enum ConfigError {
+    #[error("Invalid configuration: {0}")]
+    InvalidConfig(String),
+    #[error("Serialization error")]
+    SerializationError,
+    #[error("Unexpected rule: \n {0}")]
+    Unexpected(String),
+}

--- a/crates/configuration/src/hrmp_channel.rs
+++ b/crates/configuration/src/hrmp_channel.rs
@@ -1,10 +1,12 @@
+use serde::Serialize;
+
 use crate::shared::types::ParaId;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct HrmpChannelConfig {
-    sender: ParaId,
-    recipient: ParaId,
-    max_capacity: u32,
+    sender:           ParaId,
+    recipient:        ParaId,
+    max_capacity:     u32,
     max_message_size: u32,
 }
 

--- a/crates/configuration/src/lib.rs
+++ b/crates/configuration/src/lib.rs
@@ -1,10 +1,13 @@
+mod errors;
 mod hrmp_channel;
 mod network;
 mod parachain;
 mod relaychain;
 mod shared;
 
-pub use network::NetworkConfig;
+//
+pub use errors::ConfigError;
+pub use hrmp_channel::HrmpChannelConfig;
+pub use network::{NetworkConfig, NetworkConfigBuilder};
 pub use parachain::ParachainConfig;
 pub use relaychain::RelaychainConfig;
-pub use hrmp_channel::HrmpChannelConfig;

--- a/crates/configuration/src/main.rs
+++ b/crates/configuration/src/main.rs
@@ -1,0 +1,12 @@
+use configuration::{ConfigError, NetworkConfigBuilder};
+
+pub fn main() -> Result<(), ConfigError> {
+    let network_config = NetworkConfigBuilder::new()
+        .with_global_settings(|g| g)
+        .with_relaychain(|r| r)
+        .with_parachain(|para| para)
+        .build()?;
+
+    println!("{}", network_config.dump()?);
+    Ok(())
+}

--- a/crates/configuration/src/network.rs
+++ b/crates/configuration/src/network.rs
@@ -22,7 +22,7 @@ pub struct GlobalSettings {
 
     /// External bootnode address.
     /// [TODO]: is it a default overriden by node config, maybe an option ?
-    bootnode_address: Vec<MultiAddress>,
+    bootnodes_addresses: Vec<MultiAddress>,
 
     /// Global spawn timeout in seconds.
     network_spawn_timeout: TimeoutInSecs,

--- a/crates/configuration/src/network.rs
+++ b/crates/configuration/src/network.rs
@@ -20,7 +20,7 @@ pub struct GlobalSettings {
     /// Whether we should spawn a dedicated bootnode for each chain.
     // spawn_bootnode: bool,
 
-    /// External bootnode address.
+    /// External bootnodes addresses.
     /// [TODO]: is it a default overriden by node config, maybe an option ?
     bootnodes_addresses: Vec<MultiAddress>,
 

--- a/crates/configuration/src/network.rs
+++ b/crates/configuration/src/network.rs
@@ -1,22 +1,34 @@
+use core::marker::PhantomData;
+
+use serde::Serialize;
+
 use crate::{
-    shared::types::{Duration, IpAddress, MultiAddress},
+    errors::ConfigError,
+    shared::types::{IpAddress, MultiAddress, ParaId, TimeoutInSecs},
     HrmpChannelConfig, ParachainConfig, RelaychainConfig,
 };
 
+#[derive(Default, Clone)]
+pub struct NoRelayChain;
+#[derive(Default, Clone)]
+pub struct WithRelayChain;
+
 /// Global settings applied to an entire network.
+#[derive(Debug, Serialize)]
 pub struct GlobalSettings {
+    /// [TODO]: This feature is not well defined, which binary/image should use to spawn the bootnode?
     /// Whether we should spawn a dedicated bootnode for each chain.
-    spawn_bootnode: bool,
+    // spawn_bootnode: bool,
 
     /// External bootnode address.
     /// [TODO]: is it a default overriden by node config, maybe an option ?
-    bootnode_address: MultiAddress,
+    bootnode_address: Vec<MultiAddress>,
 
     /// Global spawn timeout in seconds.
-    network_spawn_timeout: Duration,
+    network_spawn_timeout: TimeoutInSecs,
 
     /// Individual node spawn timeout.
-    node_spawn_timeout: Duration,
+    node_spawn_timeout: TimeoutInSecs,
 
     /// Local IP used to expose local services (including RPC, metrics and monitoring).
     local_ip: Option<IpAddress>,
@@ -24,12 +36,18 @@ pub struct GlobalSettings {
 
 impl Default for GlobalSettings {
     fn default() -> Self {
-        // [TODO]: define the default value for global settings
-        todo!()
+        Self {
+            // spawn_bootnode: false,
+            bootnode_address:      vec![],
+            network_spawn_timeout: 1000,
+            node_spawn_timeout:    300,
+            local_ip:              None,
+        }
     }
 }
 
 /// A network configuration, composed of a relaychain, parachains and HRMP channels.
+#[derive(Debug, Serialize)]
 pub struct NetworkConfig {
     /// The global settings applied to the network.
     global_settings: GlobalSettings,
@@ -42,48 +60,114 @@ pub struct NetworkConfig {
 
     /// HRMP channels configurations.
     hrmp_channels: Vec<HrmpChannelConfig>,
-
-    // [TODO]: what does it represents ?
-    seed: String,
 }
 
-impl Default for NetworkConfig {
-    fn default() -> Self {
-        // [TODO]: define the default value for a network
-        todo!()
+/// A network configuration, composed of a relaychain, parachains and HRMP channels.
+#[derive(Debug, Default)]
+pub struct NetworkConfigBuilder<R> {
+    /// The global settings applied to the network.
+    global_settings: GlobalSettings,
+
+    /// Relaychain configuration.
+    relaychain: RelaychainConfig,
+
+    /// Parachains configurations.
+    parachains: Vec<ParachainConfig>,
+
+    /// HRMP channels configurations.
+    hrmp_channels: Vec<HrmpChannelConfig>,
+
+    typestate: PhantomData<R>,
+}
+
+impl NetworkConfigBuilder<NoRelayChain> {
+    pub fn new() -> Self {
+        NetworkConfigBuilder::default()
     }
 }
 
-impl NetworkConfig {
-    pub fn new() -> NetworkConfig {
-        Self::default()
+impl NetworkConfigBuilder<WithRelayChain> {
+    pub fn build(self) -> Result<NetworkConfig, ConfigError> {
+        // TODO: validate here.
+        Ok(NetworkConfig {
+            global_settings: self.global_settings,
+            relaychain:      self.relaychain,
+            parachains:      self.parachains,
+            hrmp_channels:   self.hrmp_channels,
+        })
     }
+}
 
-    pub fn with_global_settings(self, f: fn(GlobalSettings) -> GlobalSettings) -> Self {
-        Self {
+impl<R> NetworkConfigBuilder<R> {
+    pub fn with_global_settings(
+        self,
+        f: fn(GlobalSettings) -> GlobalSettings,
+    ) -> NetworkConfigBuilder<R> {
+        NetworkConfigBuilder {
             global_settings: f(self.global_settings),
             ..self
         }
     }
+}
 
-    pub fn with_relaychain(self, f: fn(RelaychainConfig) -> RelaychainConfig) -> Self {
-        Self {
-            relaychain: f(self.relaychain),
-            ..self
+impl NetworkConfigBuilder<NoRelayChain> {
+    pub fn with_relaychain(
+        self,
+        f: fn(RelaychainConfig) -> RelaychainConfig,
+    ) -> NetworkConfigBuilder<WithRelayChain> {
+        NetworkConfigBuilder {
+            relaychain:      f(RelaychainConfig::default()),
+            global_settings: self.global_settings,
+            parachains:      self.parachains,
+            hrmp_channels:   self.hrmp_channels,
+            typestate:       PhantomData,
         }
     }
+}
 
-    pub fn with_parachain(self, f: fn(ParachainConfig) -> ParachainConfig) -> Self {
+impl NetworkConfigBuilder<WithRelayChain> {
+    pub fn with_parachain(
+        self,
+        f: fn(ParachainConfig) -> ParachainConfig,
+    ) -> NetworkConfigBuilder<WithRelayChain> {
         Self {
             parachains: vec![self.parachains, vec![f(ParachainConfig::default())]].concat(),
             ..self
         }
     }
 
-    pub fn with_hrmp_channel(self, f: fn(HrmpChannelConfig) -> HrmpChannelConfig) -> Self {
+    pub fn with_hrmp_channel(
+        self,
+        f: fn(HrmpChannelConfig) -> HrmpChannelConfig,
+    ) -> NetworkConfigBuilder<WithRelayChain> {
         Self {
             hrmp_channels: vec![self.hrmp_channels, vec![f(HrmpChannelConfig::default())]].concat(),
             ..self
         }
+    }
+}
+
+impl NetworkConfig {
+    pub(crate) fn global_settings(&self) -> &GlobalSettings {
+        &self.global_settings
+    }
+
+    pub(crate) fn relaychain(&self) -> &RelaychainConfig {
+        &self.relaychain
+    }
+
+    pub(crate) fn parachains(&self) -> &Vec<ParachainConfig> {
+        &self.parachains
+    }
+
+    pub(crate) fn hrmp_channels(&self) -> &Vec<HrmpChannelConfig> {
+        &self.hrmp_channels
+    }
+
+    //[TODO]: skill serializing empty vec or None
+    pub fn dump(&self) -> Result<String, ConfigError> {
+        let config_json =
+            serde_json::to_string_pretty(&self).map_err(|_| ConfigError::SerializationError)?;
+        Ok(config_json)
     }
 }

--- a/crates/configuration/src/parachain.rs
+++ b/crates/configuration/src/parachain.rs
@@ -1,19 +1,21 @@
+use serde::Serialize;
+
 use crate::shared::{
     node::NodeConfig,
-    types::{AssetLocation, MultiAddress},
+    types::{AssetLocation, MultiAddress, ParaId},
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub enum RegistrationStrategy {
     InGenesis,
     UsingExtrinsic,
 }
 
 /// A parachain configuration, composed of collators and fine-grained configuration options.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ParachainConfig {
     // Parachain ID to use.
-    id: u16,
+    id: ParaId,
 
     /// Chain to use (use None if you are running adder-collator or undying-collator).
     chain: Option<String>,
@@ -56,13 +58,25 @@ pub struct ParachainConfig {
 
 impl Default for ParachainConfig {
     fn default() -> Self {
-        // [TODO]: define the default value for a parachain
-        todo!()
+        Self {
+            id:                      100,
+            is_cumulus_based:        true,
+            chain:                   None,
+            registration_strategy:   None,
+            initial_balance:         1000000000,
+            genesis_wasm_path:       None,
+            genesis_wasm_generator:  None,
+            genesis_state_path:      None,
+            genesis_state_generator: None,
+            chain_spec_path:         None,
+            bootnodes_addresses:     vec![],
+            collators:               vec![],
+        }
     }
 }
 
 impl ParachainConfig {
-    pub fn with_id(self, id: u16) -> Self {
+    pub fn with_id(self, id: ParaId) -> Self {
         Self { id, ..self }
     }
 
@@ -122,9 +136,9 @@ impl ParachainConfig {
         }
     }
 
-    pub fn with_cumulus(self) -> Self {
+    pub fn is_cumulus_based(self, choice: bool) -> Self {
         Self {
-            is_cumulus_based: true,
+            is_cumulus_based: choice,
             ..self
         }
     }

--- a/crates/configuration/src/shared/node.rs
+++ b/crates/configuration/src/shared/node.rs
@@ -1,24 +1,25 @@
-use crate::shared::types::{Arg, MultiAddress, Port, Resources};
+use serde::Serialize;
 
 use super::types::AssetLocation;
+use crate::shared::types::{Arg, MultiAddress, Port, Resources};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct EnvVar {
-    name: String,
+    name:  String,
     value: String,
 }
 
 impl From<(&str, &str)> for EnvVar {
     fn from((name, value): (&str, &str)) -> Self {
         Self {
-            name: name.to_owned(),
+            name:  name.to_owned(),
             value: value.to_owned(),
         }
     }
 }
 
 /// A node configuration, with fine-grained configuration options.
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize)]
 pub struct NodeConfig {
     /// Node name (should be unique or an index will be appended).
     name: String,
@@ -27,7 +28,7 @@ pub struct NodeConfig {
     image: Option<String>,
 
     /// Command to run the node. Override the default.
-    command: Option<String>,
+    command: String,
 
     /// Arguments to use for node. Appended to default.
     args: Vec<Arg>,
@@ -74,9 +75,9 @@ pub struct NodeConfig {
 }
 
 impl NodeConfig {
-    pub fn with_name(self, name: &str) -> Self {
+    pub fn with_name(self, name: impl Into<String>) -> Self {
         Self {
-            name: name.to_owned(),
+            name: name.into(),
             ..self
         }
     }
@@ -88,9 +89,9 @@ impl NodeConfig {
         }
     }
 
-    pub fn with_command(self, command: &str) -> Self {
+    pub fn with_command(self, command: impl Into<String>) -> Self {
         Self {
-            command: Some(command.to_owned()),
+            command: command.into(),
             ..self
         }
     }
@@ -99,23 +100,23 @@ impl NodeConfig {
         Self { args, ..self }
     }
 
-    pub fn being_validator(self) -> Self {
+    pub fn being_validator(self, choice: bool) -> Self {
         Self {
-            is_validator: true,
+            is_validator: choice,
             ..self
         }
     }
 
-    pub fn being_invulnerable(self) -> Self {
+    pub fn being_invulnerable(self, choice: bool) -> Self {
         Self {
-            is_invulnerable: true,
+            is_invulnerable: choice,
             ..self
         }
     }
 
-    pub fn being_bootnode(self) -> Self {
+    pub fn being_bootnode(self, choice: bool) -> Self {
         Self {
-            is_bootnode: true,
+            is_bootnode: choice,
             ..self
         }
     }
@@ -195,8 +196,8 @@ impl NodeConfig {
         self.image.as_deref()
     }
 
-    pub fn command(&self) -> Option<&str> {
-        self.command.as_deref()
+    pub fn command(&self) -> &str {
+        self.command.as_ref()
     }
 
     pub fn args(&self) -> Vec<&Arg> {
@@ -278,9 +279,9 @@ mod tests {
 
     #[test]
     fn with_command_should_update_the_command_on_the_node_config() {
-        let node_config = NodeConfig::default().with_command("my command to run");
+        let node_config = NodeConfig::default().with_command("substrate");
 
-        assert_eq!(node_config.command().unwrap(), "my command to run");
+        assert_eq!(node_config.command(), "substrate");
     }
 
     #[test]
@@ -293,21 +294,21 @@ mod tests {
 
     #[test]
     fn as_validator_should_update_the_is_validator_property_on_the_node_config() {
-        let node_config = NodeConfig::default().being_validator();
+        let node_config = NodeConfig::default().being_validator(true);
 
         assert!(node_config.is_validator());
     }
 
     #[test]
     fn as_invulnerable_should_update_the_is_invulnerable_property_on_the_node_config() {
-        let node_config = NodeConfig::default().being_invulnerable();
+        let node_config = NodeConfig::default().being_invulnerable(true);
 
         assert!(node_config.is_invulnerable());
     }
 
     #[test]
     fn as_bootnode_should_update_the_is_bootnode_property_on_the_node_config() {
-        let node_config = NodeConfig::default().being_bootnode();
+        let node_config = NodeConfig::default().being_bootnode(true);
 
         assert!(node_config.is_bootnode());
     }

--- a/crates/configuration/src/shared/types.rs
+++ b/crates/configuration/src/shared/types.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Clone, PartialEq)]
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct MultiAddress(String);
 
 impl MultiAddress {
@@ -13,17 +15,16 @@ impl From<&str> for MultiAddress {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct IpAddress(String);
 
-#[derive(Debug, Clone)]
-pub struct Duration(String);
+pub type TimeoutInSecs = u16;
 
 pub type Port = u16;
 
 pub type ParaId = u32;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ResourceQuantity(String);
 
 impl ResourceQuantity {
@@ -38,12 +39,12 @@ impl From<&str> for ResourceQuantity {
     }
 }
 
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize)]
 pub struct Resources {
     request_memory: Option<ResourceQuantity>,
-    request_cpu: Option<ResourceQuantity>,
-    limit_memory: Option<ResourceQuantity>,
-    limit_cpu: Option<ResourceQuantity>,
+    request_cpu:    Option<ResourceQuantity>,
+    limit_memory:   Option<ResourceQuantity>,
+    limit_cpu:      Option<ResourceQuantity>,
 }
 
 impl Resources {
@@ -92,7 +93,7 @@ impl Resources {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum AssetLocation {
     Url(String),
     FilePath(String),
@@ -100,7 +101,7 @@ pub enum AssetLocation {
 
 /// A CLI argument, can be an option with an assigned value or a simple
 /// flag to enable/disable a feature.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum Arg {
     Flag(String),
     Option(String, String),


### PR DESCRIPTION
[DRAFT], just to open the discussion about the API:

-  The `NetworkConfig` now should be built using the `NetworkConfigBuilder` (with type state to ensure `.with_relaychain` is called ones).
- Add same `Defaults` we use now in the `ts` version.
- Add `choice` to methods like `being_validator` since the default is `true` and we want to allow to set to false. We should revisit the naming here.
- Remove Settings/ options that we should revisit.
- Add `thiserror` to handle `ConfigErrors`
- Add serde for `dump` the config to json.
- Lots of `TODO` to visit and add test :)