### PR TITLE
Simplify the node builder to allow default_command

### DIFF
--- a/crates/configuration/src/parachain.rs
+++ b/crates/configuration/src/parachain.rs
@@ -160,7 +160,7 @@ impl ParachainConfigBuilder<WithId> {
         self,
         f: fn(NodeConfigBuilder<node::Initial>) -> NodeConfigBuilder<node::Buildable>,
     ) -> ParachainConfigBuilder<WithAtLeastOneCollator> {
-        let new_collator = f(NodeConfigBuilder::new()).build();
+        let new_collator = f(NodeConfigBuilder::new(None)).build();
 
         Self::transition(ParachainConfig {
             collators: vec![new_collator],
@@ -244,7 +244,7 @@ impl ParachainConfigBuilder<WithAtLeastOneCollator> {
         self,
         f: fn(NodeConfigBuilder<node::Initial>) -> NodeConfigBuilder<node::Buildable>,
     ) -> Self {
-        let new_collator = f(NodeConfigBuilder::new()).build();
+        let new_collator = f(NodeConfigBuilder::new(None)).build();
 
         Self::transition(ParachainConfig {
             collators: vec![self.config.collators, vec![new_collator]].concat(),

--- a/crates/configuration/src/shared/node.rs
+++ b/crates/configuration/src/shared/node.rs
@@ -149,9 +149,6 @@ impl NodeConfig {
 
 states! {
     Initial,
-    WithName,
-    WithCommand,
-    WithDefaultCommand,
     Buildable
 }
 
@@ -198,63 +195,16 @@ impl<A> NodeConfigBuilder<A> {
 }
 
 impl NodeConfigBuilder<Initial> {
-    pub fn new() -> NodeConfigBuilder<Initial> {
-        Self::default()
-    }
-
-    pub fn new_with_default_command(
-        default_command: String,
-    ) -> NodeConfigBuilder<WithDefaultCommand> {
+    pub fn new(default_command: Option<String>) -> Self {
         Self::transition(NodeConfig {
-            command: Some(default_command),
+            command: default_command,
             ..Self::default().config
         })
     }
 
-    pub fn with_name(self, name: impl Into<String>) -> NodeConfigBuilder<WithName> {
-        Self::transition(NodeConfig {
-            name: name.into(),
-            ..self.config
-        })
-    }
-
-    pub fn with_command(self, command: impl Into<String>) -> NodeConfigBuilder<WithCommand> {
-        Self::transition(NodeConfig {
-            command: Some(command.into()),
-            ..self.config
-        })
-    }
-}
-
-impl NodeConfigBuilder<WithName> {
-    pub fn with_command(self, command: impl Into<String>) -> NodeConfigBuilder<Buildable> {
-        Self::transition(NodeConfig {
-            command: Some(command.into()),
-            ..self.config
-        })
-    }
-}
-
-impl NodeConfigBuilder<WithCommand> {
     pub fn with_name(self, name: impl Into<String>) -> NodeConfigBuilder<Buildable> {
         Self::transition(NodeConfig {
             name: name.into(),
-            ..self.config
-        })
-    }
-}
-
-impl NodeConfigBuilder<WithDefaultCommand> {
-    pub fn with_name(self, name: impl Into<String>) -> NodeConfigBuilder<Buildable> {
-        Self::transition(NodeConfig {
-            name: name.into(),
-            ..self.config
-        })
-    }
-
-    pub fn with_command(self, command: impl Into<String>) -> NodeConfigBuilder<WithCommand> {
-        Self::transition(NodeConfig {
-            command: Some(command.into()),
             ..self.config
         })
     }
@@ -383,7 +333,7 @@ mod tests {
 
     #[test]
     fn node_config_builder_should_build_a_new_node_config_correctly() {
-        let node_config = NodeConfigBuilder::new()
+        let node_config = NodeConfigBuilder::new(None)
             .with_name("node")
             .with_command("mycommand")
             .with_image("myrepo:myimage")


### PR DESCRIPTION
We want the user to be able to set a default command on the relaychain and to override it, to make it type safe, using a Either type with both possible options and a further step of validation to ensure the user defined a command on the node, here a code example with a schema showing what we want to achieve:

![sdk_either_initial_default_command](https://github.com/paritytech/zombienet-sdk/assets/45130584/58d4aa89-e003-441d-96b5-fb9b36d82bf9)
