### PR TITLE
Refacto/node relaychain defaults

### DIFF
--- a/crates/configuration/src/parachain.rs
+++ b/crates/configuration/src/parachain.rs
@@ -170,7 +170,7 @@ impl ParachainConfigBuilder<WithId> {
         self,
         f: fn(NodeConfigBuilder<node::Initial>) -> NodeConfigBuilder<node::Buildable>,
     ) -> ParachainConfigBuilder<WithAtLeastOneCollator> {
-        match f(NodeConfigBuilder::new(None)).build() {
+        match f(NodeConfigBuilder::new(None, None, None, None, vec![])).build() {
             Ok(collator) => Self::transition(
                 ParachainConfig {
                     collators: vec![collator],
@@ -349,7 +349,7 @@ impl ParachainConfigBuilder<WithAtLeastOneCollator> {
         self,
         f: fn(NodeConfigBuilder<node::Initial>) -> NodeConfigBuilder<node::Buildable>,
     ) -> Self {
-        match f(NodeConfigBuilder::new(None)).build() {
+        match f(NodeConfigBuilder::new(None, None, None, None, vec![])).build() {
             Ok(collator) => Self::transition(
                 ParachainConfig {
                     collators: vec![self.config.collators, vec![collator]].concat(),

--- a/crates/configuration/src/parachain.rs
+++ b/crates/configuration/src/parachain.rs
@@ -7,7 +7,7 @@ use crate::shared::{
     helpers::{merge_errors, merge_errors_vecs},
     macros::states,
     node::{self, NodeConfig, NodeConfigBuilder},
-    types::{AssetLocation, Chain, Command, ParaId},
+    types::{AssetLocation, Chain, ChainDefaultContext, Command, ParaId},
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -170,7 +170,7 @@ impl ParachainConfigBuilder<WithId> {
         self,
         f: fn(NodeConfigBuilder<node::Initial>) -> NodeConfigBuilder<node::Buildable>,
     ) -> ParachainConfigBuilder<WithAtLeastOneCollator> {
-        match f(NodeConfigBuilder::new(None, None, None, None, vec![])).build() {
+        match f(NodeConfigBuilder::new(ChainDefaultContext::default())).build() {
             Ok(collator) => Self::transition(
                 ParachainConfig {
                     collators: vec![collator],
@@ -349,7 +349,7 @@ impl ParachainConfigBuilder<WithAtLeastOneCollator> {
         self,
         f: fn(NodeConfigBuilder<node::Initial>) -> NodeConfigBuilder<node::Buildable>,
     ) -> Self {
-        match f(NodeConfigBuilder::new(None, None, None, None, vec![])).build() {
+        match f(NodeConfigBuilder::new(ChainDefaultContext::default())).build() {
             Ok(collator) => Self::transition(
                 ParachainConfig {
                     collators: vec![self.config.collators, vec![collator]].concat(),

--- a/crates/configuration/src/relaychain.rs
+++ b/crates/configuration/src/relaychain.rs
@@ -27,11 +27,11 @@ pub struct RelaychainConfig {
     /// Default database snapshot. Can be overriden on each node.
     default_db_snapshot: Option<AssetLocation>,
 
-    /// Chain specification JSON file to use.
-    chain_spec_path: Option<AssetLocation>,
-
     /// Default arguments to use in nodes. Can be overriden on each node.
     default_args: Vec<Arg>,
+
+    /// Chain specification JSON file to use.
+    chain_spec_path: Option<AssetLocation>,
 
     /// Set the count of nominators to generator (used with PoS networks).
     random_nominators_count: Option<u32>,
@@ -88,104 +88,7 @@ impl RelaychainConfig {
 states! {
     Initial,
     WithChain,
-    WithAtLeastOneNode,
-    WithDefaultCommand
-}
-
-macro_rules! common_builder_methods {
-    () => {
-        pub fn with_default_image<T>(self, image: T) -> Self
-        where
-            T: TryInto<Image>,
-            T::Error: Error + Send + Sync + 'static,
-        {
-            match image.try_into() {
-                Ok(image) => Self::transition(
-                    RelaychainConfig {
-                        default_image: Some(image),
-                        ..self.config
-                    },
-                    self.errors,
-                ),
-                Err(error) => Self::transition(
-                    self.config,
-                    merge_errors(self.errors, FieldError::DefaultImage(error.into()).into()),
-                ),
-            }
-        }
-
-        pub fn with_default_resources(self, f: fn(ResourcesBuilder) -> ResourcesBuilder) -> Self {
-            match f(ResourcesBuilder::new()).build() {
-                Ok(default_resources) => Self::transition(
-                    RelaychainConfig {
-                        default_resources: Some(default_resources),
-                        ..self.config
-                    },
-                    self.errors,
-                ),
-                Err(errors) => Self::transition(
-                    self.config,
-                    merge_errors_vecs(
-                        self.errors,
-                        errors
-                            .into_iter()
-                            .map(|error| FieldError::DefaultResources(error).into())
-                            .collect::<Vec<_>>(),
-                    ),
-                ),
-            }
-        }
-
-        pub fn with_default_db_snapshot(self, location: impl Into<AssetLocation>) -> Self {
-            Self::transition(
-                RelaychainConfig {
-                    default_db_snapshot: Some(location.into()),
-                    ..self.config
-                },
-                self.errors,
-            )
-        }
-
-        pub fn with_chain_spec_path(self, location: impl Into<AssetLocation>) -> Self {
-            Self::transition(
-                RelaychainConfig {
-                    chain_spec_path: Some(location.into()),
-                    ..self.config
-                },
-                self.errors,
-            )
-        }
-
-        pub fn with_default_args(self, args: Vec<Arg>) -> Self {
-            Self::transition(
-                RelaychainConfig {
-                    default_args: args,
-                    ..self.config
-                },
-                self.errors,
-            )
-        }
-
-        pub fn with_random_nominators_count(self, random_nominators_count: u32) -> Self {
-            Self::transition(
-                RelaychainConfig {
-                    random_nominators_count: Some(random_nominators_count),
-                    ..self.config
-                },
-                self.errors,
-            )
-        }
-
-        pub fn with_max_nominations(self, max_nominations: u8) -> Self {
-            Self::transition(
-                RelaychainConfig {
-                    max_nominations: Some(max_nominations),
-                    ..self.config
-                },
-                self.errors,
-            )
-        }
-    };
+    WithAtLeastOneNode
 }
 
 #[derive(Debug)]
@@ -258,9 +161,7 @@ impl RelaychainConfigBuilder<Initial> {
 }
 
 impl RelaychainConfigBuilder<WithChain> {
-    common_builder_methods!();
-
-    pub fn with_default_command<T>(self, command: T) -> RelaychainConfigBuilder<WithDefaultCommand>
+    pub fn with_default_command<T>(self, command: T) -> Self
     where
         T: TryInto<Command>,
         T::Error: Error + Send + Sync + 'static,
@@ -280,42 +181,111 @@ impl RelaychainConfigBuilder<WithChain> {
         }
     }
 
-    pub fn with_node(
-        self,
-        f: fn(NodeConfigBuilder<node::Initial>) -> NodeConfigBuilder<node::Buildable>,
-    ) -> RelaychainConfigBuilder<WithAtLeastOneNode> {
-        match f(NodeConfigBuilder::new(None)).build() {
-            Ok(node) => Self::transition(
+    pub fn with_default_image<T>(self, image: T) -> Self
+    where
+        T: TryInto<Image>,
+        T::Error: Error + Send + Sync + 'static,
+    {
+        match image.try_into() {
+            Ok(image) => Self::transition(
                 RelaychainConfig {
-                    nodes: vec![node],
+                    default_image: Some(image),
                     ..self.config
                 },
                 self.errors,
             ),
-            Err((name, errors)) => Self::transition(
+            Err(error) => Self::transition(
+                self.config,
+                merge_errors(self.errors, FieldError::DefaultImage(error.into()).into()),
+            ),
+        }
+    }
+
+    pub fn with_default_resources(self, f: fn(ResourcesBuilder) -> ResourcesBuilder) -> Self {
+        match f(ResourcesBuilder::new()).build() {
+            Ok(default_resources) => Self::transition(
+                RelaychainConfig {
+                    default_resources: Some(default_resources),
+                    ..self.config
+                },
+                self.errors,
+            ),
+            Err(errors) => Self::transition(
                 self.config,
                 merge_errors_vecs(
                     self.errors,
                     errors
                         .into_iter()
-                        .map(|error| ConfigError::Node(name.clone(), error).into())
+                        .map(|error| FieldError::DefaultResources(error).into())
                         .collect::<Vec<_>>(),
                 ),
             ),
         }
     }
-}
 
-impl RelaychainConfigBuilder<WithDefaultCommand> {
-    common_builder_methods!();
+    pub fn with_default_db_snapshot(self, location: impl Into<AssetLocation>) -> Self {
+        Self::transition(
+            RelaychainConfig {
+                default_db_snapshot: Some(location.into()),
+                ..self.config
+            },
+            self.errors,
+        )
+    }
+
+    pub fn with_default_args(self, args: Vec<Arg>) -> Self {
+        Self::transition(
+            RelaychainConfig {
+                default_args: args,
+                ..self.config
+            },
+            self.errors,
+        )
+    }
+
+    pub fn with_chain_spec_path(self, location: impl Into<AssetLocation>) -> Self {
+        Self::transition(
+            RelaychainConfig {
+                chain_spec_path: Some(location.into()),
+                ..self.config
+            },
+            self.errors,
+        )
+    }
+
+    pub fn with_random_nominators_count(self, random_nominators_count: u32) -> Self {
+        Self::transition(
+            RelaychainConfig {
+                random_nominators_count: Some(random_nominators_count),
+                ..self.config
+            },
+            self.errors,
+        )
+    }
+
+    pub fn with_max_nominations(self, max_nominations: u8) -> Self {
+        Self::transition(
+            RelaychainConfig {
+                max_nominations: Some(max_nominations),
+                ..self.config
+            },
+            self.errors,
+        )
+    }
 
     pub fn with_node(
         self,
         f: fn(NodeConfigBuilder<node::Initial>) -> NodeConfigBuilder<node::Buildable>,
     ) -> RelaychainConfigBuilder<WithAtLeastOneNode> {
-        let default_command = self.config.default_command.clone();
-
-        match f(NodeConfigBuilder::new(default_command)).build() {
+        match f(NodeConfigBuilder::new(
+            self.config.default_command.clone(),
+            self.config.default_image.clone(),
+            self.config.default_resources.clone(),
+            self.config.default_db_snapshot.clone(),
+            self.config.default_args.clone(),
+        ))
+        .build()
+        {
             Ok(node) => Self::transition(
                 RelaychainConfig {
                     nodes: vec![node],
@@ -342,7 +312,15 @@ impl RelaychainConfigBuilder<WithAtLeastOneNode> {
         self,
         f: fn(NodeConfigBuilder<node::Initial>) -> NodeConfigBuilder<node::Buildable>,
     ) -> Self {
-        match f(NodeConfigBuilder::new(self.config.default_command.clone())).build() {
+        match f(NodeConfigBuilder::new(
+            self.config.default_command.clone(),
+            self.config.default_image.clone(),
+            self.config.default_resources.clone(),
+            self.config.default_db_snapshot.clone(),
+            self.config.default_args.clone(),
+        ))
+        .build()
+        {
             Ok(node) => Self::transition(
                 RelaychainConfig {
                     nodes: vec![self.config.nodes, vec![node]].concat(),

--- a/crates/configuration/src/shared/node.rs
+++ b/crates/configuration/src/shared/node.rs
@@ -7,7 +7,7 @@ use super::{
     helpers::{merge_errors, merge_errors_vecs},
     macros::states,
     resources::ResourcesBuilder,
-    types::{AssetLocation, Command, Image},
+    types::{AssetLocation, ChainDefaultContext, Command, Image},
 };
 use crate::shared::{
     resources::Resources,
@@ -206,20 +206,14 @@ impl<A> NodeConfigBuilder<A> {
 }
 
 impl NodeConfigBuilder<Initial> {
-    pub fn new(
-        default_command: Option<Command>,
-        default_image: Option<Image>,
-        default_resources: Option<Resources>,
-        default_db_snapshot: Option<AssetLocation>,
-        default_args: Vec<Arg>,
-    ) -> Self {
+    pub fn new(context: ChainDefaultContext) -> Self {
         Self::transition(
             NodeConfig {
-                command: default_command,
-                image: default_image,
-                resources: default_resources,
-                db_snapshot: default_db_snapshot,
-                args: default_args,
+                command: context.default_command,
+                image: context.default_image,
+                resources: context.default_resources,
+                db_snapshot: context.default_db_snapshot,
+                args: context.default_args,
                 ..Self::default().config
             },
             vec![],
@@ -457,7 +451,7 @@ mod tests {
 
     #[test]
     fn node_config_builder_should_succeeds_and_returns_a_node_config() {
-        let node_config = NodeConfigBuilder::new(None, None, None, None, vec![])
+        let node_config = NodeConfigBuilder::new(ChainDefaultContext::default())
             .with_name("node")
             .with_command("mycommand")
             .with_image("myrepo:myimage")
@@ -526,7 +520,7 @@ mod tests {
 
     #[test]
     fn node_config_builder_should_fails_and_returns_an_error_and_node_name_if_command_is_invalid() {
-        let (node_name, errors) = NodeConfigBuilder::new(None, None, None, None, vec![])
+        let (node_name, errors) = NodeConfigBuilder::new(ChainDefaultContext::default())
             .with_name("node")
             .with_command("invalid command")
             .build()
@@ -542,7 +536,7 @@ mod tests {
 
     #[test]
     fn node_config_builder_should_fails_and_returns_an_error_and_node_name_if_image_is_invalid() {
-        let (node_name, errors) = NodeConfigBuilder::new(None, None, None, None, vec![])
+        let (node_name, errors) = NodeConfigBuilder::new(ChainDefaultContext::default())
             .with_name("node")
             .with_image("myinvalid.image")
             .build()
@@ -559,7 +553,7 @@ mod tests {
     #[test]
     fn node_config_builder_should_fails_and_returns_an_error_and_node_name_if_one_bootnode_address_is_invalid(
     ) {
-        let (node_name, errors) = NodeConfigBuilder::new(None, None, None, None, vec![])
+        let (node_name, errors) = NodeConfigBuilder::new(ChainDefaultContext::default())
             .with_name("node")
             .with_bootnodes_addresses(vec!["/ip4//tcp/45421"])
             .build()
@@ -576,7 +570,7 @@ mod tests {
     #[test]
     fn node_config_builder_should_fails_and_returns_mulitle_errors_and_node_name_if_multiple_bootnode_address_are_invalid(
     ) {
-        let (node_name, errors) = NodeConfigBuilder::new(None, None, None, None, vec![])
+        let (node_name, errors) = NodeConfigBuilder::new(ChainDefaultContext::default())
             .with_name("node")
             .with_bootnodes_addresses(vec!["/ip4//tcp/45421", "//10.42.153.10/tcp/43111"])
             .build()
@@ -597,7 +591,7 @@ mod tests {
     #[test]
     fn node_config_builder_should_fails_and_returns_an_error_and_node_name_if_resources_has_an_error(
     ) {
-        let (node_name, errors) = NodeConfigBuilder::new(None, None, None, None, vec![])
+        let (node_name, errors) = NodeConfigBuilder::new(ChainDefaultContext::default())
             .with_name("node")
             .with_resources(|resources| resources.with_limit_cpu("invalid"))
             .build()
@@ -614,7 +608,7 @@ mod tests {
     #[test]
     fn node_config_builder_should_fails_and_returns_multiple_errors_and_node_name_if_resources_has_multiple_errors(
     ) {
-        let (node_name, errors) = NodeConfigBuilder::new(None, None, None, None, vec![])
+        let (node_name, errors) = NodeConfigBuilder::new(ChainDefaultContext::default())
             .with_name("node")
             .with_resources(|resources| {
                 resources
@@ -639,7 +633,7 @@ mod tests {
     #[test]
     fn node_config_builder_should_fails_and_returns_multiple_errors_and_node_name_if_multiple_fields_have_errors(
     ) {
-        let (node_name, errors) = NodeConfigBuilder::new(None, None, None, None, vec![])
+        let (node_name, errors) = NodeConfigBuilder::new(ChainDefaultContext::default())
             .with_name("node")
             .with_command("invalid command")
             .with_image("myinvalid.image")

--- a/crates/configuration/src/shared/node.rs
+++ b/crates/configuration/src/shared/node.rs
@@ -206,10 +206,20 @@ impl<A> NodeConfigBuilder<A> {
 }
 
 impl NodeConfigBuilder<Initial> {
-    pub fn new(default_command: Option<Command>) -> Self {
+    pub fn new(
+        default_command: Option<Command>,
+        default_image: Option<Image>,
+        default_resources: Option<Resources>,
+        default_db_snapshot: Option<AssetLocation>,
+        default_args: Vec<Arg>,
+    ) -> Self {
         Self::transition(
             NodeConfig {
                 command: default_command,
+                image: default_image,
+                resources: default_resources,
+                db_snapshot: default_db_snapshot,
+                args: default_args,
                 ..Self::default().config
             },
             vec![],
@@ -447,7 +457,7 @@ mod tests {
 
     #[test]
     fn node_config_builder_should_succeeds_and_returns_a_node_config() {
-        let node_config = NodeConfigBuilder::new(None)
+        let node_config = NodeConfigBuilder::new(None, None, None, None, vec![])
             .with_name("node")
             .with_command("mycommand")
             .with_image("myrepo:myimage")
@@ -516,7 +526,7 @@ mod tests {
 
     #[test]
     fn node_config_builder_should_fails_and_returns_an_error_and_node_name_if_command_is_invalid() {
-        let (node_name, errors) = NodeConfigBuilder::new(None)
+        let (node_name, errors) = NodeConfigBuilder::new(None, None, None, None, vec![])
             .with_name("node")
             .with_command("invalid command")
             .build()
@@ -532,7 +542,7 @@ mod tests {
 
     #[test]
     fn node_config_builder_should_fails_and_returns_an_error_and_node_name_if_image_is_invalid() {
-        let (node_name, errors) = NodeConfigBuilder::new(None)
+        let (node_name, errors) = NodeConfigBuilder::new(None, None, None, None, vec![])
             .with_name("node")
             .with_image("myinvalid.image")
             .build()
@@ -549,7 +559,7 @@ mod tests {
     #[test]
     fn node_config_builder_should_fails_and_returns_an_error_and_node_name_if_one_bootnode_address_is_invalid(
     ) {
-        let (node_name, errors) = NodeConfigBuilder::new(None)
+        let (node_name, errors) = NodeConfigBuilder::new(None, None, None, None, vec![])
             .with_name("node")
             .with_bootnodes_addresses(vec!["/ip4//tcp/45421"])
             .build()
@@ -566,7 +576,7 @@ mod tests {
     #[test]
     fn node_config_builder_should_fails_and_returns_mulitle_errors_and_node_name_if_multiple_bootnode_address_are_invalid(
     ) {
-        let (node_name, errors) = NodeConfigBuilder::new(None)
+        let (node_name, errors) = NodeConfigBuilder::new(None, None, None, None, vec![])
             .with_name("node")
             .with_bootnodes_addresses(vec!["/ip4//tcp/45421", "//10.42.153.10/tcp/43111"])
             .build()
@@ -587,7 +597,7 @@ mod tests {
     #[test]
     fn node_config_builder_should_fails_and_returns_an_error_and_node_name_if_resources_has_an_error(
     ) {
-        let (node_name, errors) = NodeConfigBuilder::new(None)
+        let (node_name, errors) = NodeConfigBuilder::new(None, None, None, None, vec![])
             .with_name("node")
             .with_resources(|resources| resources.with_limit_cpu("invalid"))
             .build()
@@ -604,7 +614,7 @@ mod tests {
     #[test]
     fn node_config_builder_should_fails_and_returns_multiple_errors_and_node_name_if_resources_has_multiple_errors(
     ) {
-        let (node_name, errors) = NodeConfigBuilder::new(None)
+        let (node_name, errors) = NodeConfigBuilder::new(None, None, None, None, vec![])
             .with_name("node")
             .with_resources(|resources| {
                 resources
@@ -629,7 +639,7 @@ mod tests {
     #[test]
     fn node_config_builder_should_fails_and_returns_multiple_errors_and_node_name_if_multiple_fields_have_errors(
     ) {
-        let (node_name, errors) = NodeConfigBuilder::new(None)
+        let (node_name, errors) = NodeConfigBuilder::new(None, None, None, None, vec![])
             .with_name("node")
             .with_command("invalid command")
             .with_image("myinvalid.image")

--- a/crates/configuration/src/shared/types.rs
+++ b/crates/configuration/src/shared/types.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use url::Url;
 
-use super::errors::ConversionError;
+use super::{errors::ConversionError, resources::Resources};
 
 pub type Duration = u32;
 
@@ -137,6 +137,15 @@ impl From<(&str, &str)> for Arg {
     fn from((option, value): (&str, &str)) -> Self {
         Self::Option(option.to_owned(), value.to_owned())
     }
+}
+
+#[derive(Default)]
+pub struct ChainDefaultContext {
+    pub(crate) default_command: Option<Command>,
+    pub(crate) default_image: Option<Image>,
+    pub(crate) default_resources: Option<Resources>,
+    pub(crate) default_db_snapshot: Option<AssetLocation>,
+    pub(crate) default_args: Vec<Arg>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fix https://github.com/paritytech/zombienet-sdk/issues/81, simplified RelaychainConfigBuilder typestate to avoid macro and allow correct order of methods, used defined default to create new NodeConfigBuilder