### PR TITLE
add ChainDefaultContext to pass the default context to node config bu…

### DIFF
--- a/crates/configuration/src/parachain.rs
+++ b/crates/configuration/src/parachain.rs
@@ -7,7 +7,7 @@ use crate::shared::{
     helpers::{merge_errors, merge_errors_vecs},
     macros::states,
     node::{self, NodeConfig, NodeConfigBuilder},
-    types::{AssetLocation, Chain, Command, ParaId},
+    types::{AssetLocation, Chain, ChainDefaultContext, Command, ParaId},
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -170,7 +170,7 @@ impl ParachainConfigBuilder<WithId> {
         self,
         f: fn(NodeConfigBuilder<node::Initial>) -> NodeConfigBuilder<node::Buildable>,
     ) -> ParachainConfigBuilder<WithAtLeastOneCollator> {
-        match f(NodeConfigBuilder::new(None, None, None, None, vec![])).build() {
+        match f(NodeConfigBuilder::new(ChainDefaultContext::default())).build() {
             Ok(collator) => Self::transition(
                 ParachainConfig {
                     collators: vec![collator],
@@ -349,7 +349,7 @@ impl ParachainConfigBuilder<WithAtLeastOneCollator> {
         self,
         f: fn(NodeConfigBuilder<node::Initial>) -> NodeConfigBuilder<node::Buildable>,
     ) -> Self {
-        match f(NodeConfigBuilder::new(None, None, None, None, vec![])).build() {
+        match f(NodeConfigBuilder::new(ChainDefaultContext::default())).build() {
             Ok(collator) => Self::transition(
                 ParachainConfig {
                     collators: vec![self.config.collators, vec![collator]].concat(),

--- a/crates/configuration/src/shared/node.rs
+++ b/crates/configuration/src/shared/node.rs
@@ -7,7 +7,7 @@ use super::{
     helpers::{merge_errors, merge_errors_vecs},
     macros::states,
     resources::ResourcesBuilder,
-    types::{AssetLocation, Command, Image},
+    types::{AssetLocation, ChainDefaultContext, Command, Image},
 };
 use crate::shared::{
     resources::Resources,
@@ -206,20 +206,14 @@ impl<A> NodeConfigBuilder<A> {
 }
 
 impl NodeConfigBuilder<Initial> {
-    pub fn new(
-        default_command: Option<Command>,
-        default_image: Option<Image>,
-        default_resources: Option<Resources>,
-        default_db_snapshot: Option<AssetLocation>,
-        default_args: Vec<Arg>,
-    ) -> Self {
+    pub fn new(chain_default_context: ChainDefaultContext) -> Self {
         Self::transition(
             NodeConfig {
-                command: default_command,
-                image: default_image,
-                resources: default_resources,
-                db_snapshot: default_db_snapshot,
-                args: default_args,
+                command: chain_default_context.default_command,
+                image: chain_default_context.default_image,
+                resources: chain_default_context.default_resources,
+                db_snapshot: chain_default_context.default_db_snapshot,
+                args: chain_default_context.default_args,
                 ..Self::default().config
             },
             vec![],
@@ -457,7 +451,7 @@ mod tests {
 
     #[test]
     fn node_config_builder_should_succeeds_and_returns_a_node_config() {
-        let node_config = NodeConfigBuilder::new(None, None, None, None, vec![])
+        let node_config = NodeConfigBuilder::new(ChainDefaultContext::default())
             .with_name("node")
             .with_command("mycommand")
             .with_image("myrepo:myimage")
@@ -526,7 +520,7 @@ mod tests {
 
     #[test]
     fn node_config_builder_should_fails_and_returns_an_error_and_node_name_if_command_is_invalid() {
-        let (node_name, errors) = NodeConfigBuilder::new(None, None, None, None, vec![])
+        let (node_name, errors) = NodeConfigBuilder::new(ChainDefaultContext::default())
             .with_name("node")
             .with_command("invalid command")
             .build()
@@ -542,7 +536,7 @@ mod tests {
 
     #[test]
     fn node_config_builder_should_fails_and_returns_an_error_and_node_name_if_image_is_invalid() {
-        let (node_name, errors) = NodeConfigBuilder::new(None, None, None, None, vec![])
+        let (node_name, errors) = NodeConfigBuilder::new(ChainDefaultContext::default())
             .with_name("node")
             .with_image("myinvalid.image")
             .build()
@@ -559,7 +553,7 @@ mod tests {
     #[test]
     fn node_config_builder_should_fails_and_returns_an_error_and_node_name_if_one_bootnode_address_is_invalid(
     ) {
-        let (node_name, errors) = NodeConfigBuilder::new(None, None, None, None, vec![])
+        let (node_name, errors) = NodeConfigBuilder::new(ChainDefaultContext::default())
             .with_name("node")
             .with_bootnodes_addresses(vec!["/ip4//tcp/45421"])
             .build()
@@ -576,7 +570,7 @@ mod tests {
     #[test]
     fn node_config_builder_should_fails_and_returns_mulitle_errors_and_node_name_if_multiple_bootnode_address_are_invalid(
     ) {
-        let (node_name, errors) = NodeConfigBuilder::new(None, None, None, None, vec![])
+        let (node_name, errors) = NodeConfigBuilder::new(ChainDefaultContext::default())
             .with_name("node")
             .with_bootnodes_addresses(vec!["/ip4//tcp/45421", "//10.42.153.10/tcp/43111"])
             .build()
@@ -597,7 +591,7 @@ mod tests {
     #[test]
     fn node_config_builder_should_fails_and_returns_an_error_and_node_name_if_resources_has_an_error(
     ) {
-        let (node_name, errors) = NodeConfigBuilder::new(None, None, None, None, vec![])
+        let (node_name, errors) = NodeConfigBuilder::new(ChainDefaultContext::default())
             .with_name("node")
             .with_resources(|resources| resources.with_limit_cpu("invalid"))
             .build()
@@ -614,7 +608,7 @@ mod tests {
     #[test]
     fn node_config_builder_should_fails_and_returns_multiple_errors_and_node_name_if_resources_has_multiple_errors(
     ) {
-        let (node_name, errors) = NodeConfigBuilder::new(None, None, None, None, vec![])
+        let (node_name, errors) = NodeConfigBuilder::new(ChainDefaultContext::default())
             .with_name("node")
             .with_resources(|resources| {
                 resources
@@ -639,7 +633,7 @@ mod tests {
     #[test]
     fn node_config_builder_should_fails_and_returns_multiple_errors_and_node_name_if_multiple_fields_have_errors(
     ) {
-        let (node_name, errors) = NodeConfigBuilder::new(None, None, None, None, vec![])
+        let (node_name, errors) = NodeConfigBuilder::new(ChainDefaultContext::default())
             .with_name("node")
             .with_command("invalid command")
             .with_image("myinvalid.image")

--- a/crates/configuration/src/shared/types.rs
+++ b/crates/configuration/src/shared/types.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use url::Url;
 
-use super::errors::ConversionError;
+use super::{errors::ConversionError, resources::Resources};
 
 pub type Duration = u32;
 
@@ -137,6 +137,15 @@ impl From<(&str, &str)> for Arg {
     fn from((option, value): (&str, &str)) -> Self {
         Self::Option(option.to_owned(), value.to_owned())
     }
+}
+
+#[derive(Default)]
+pub struct ChainDefaultContext {
+    pub(crate) default_command: Option<Command>,
+    pub(crate) default_image: Option<Image>,
+    pub(crate) default_resources: Option<Resources>,
+    pub(crate) default_db_snapshot: Option<AssetLocation>,
+    pub(crate) default_args: Vec<Arg>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
…ilder

---
- Add struct `ChainDefaultContext` to hold the chain context defaults to be passed to the node config builder.
- Add method in `relaychain` config builder to get the `default_context` (needs docs)
- Change in `tests` to use `ChainDefaultContext::Default` (derived).