### PR TITLE
Feat/missing onboard as parachain field

### DIFF
--- a/crates/configuration/src/lib.rs
+++ b/crates/configuration/src/lib.rs
@@ -4,6 +4,7 @@ mod network;
 mod parachain;
 mod relaychain;
 pub mod shared;
+mod utils;
 
 pub use global_settings::{GlobalSettings, GlobalSettingsBuilder};
 pub use hrmp_channel::{HrmpChannelConfig, HrmpChannelConfigBuilder};

--- a/crates/configuration/src/network.rs
+++ b/crates/configuration/src/network.rs
@@ -283,6 +283,8 @@ impl NetworkConfigBuilder<WithRelaychain> {
 mod tests {
     use std::fs;
 
+    use crate::parachain::RegistrationStrategy;
+
     use super::*;
 
     #[test]
@@ -699,6 +701,8 @@ mod tests {
                     .with_id(1000)
                     .with_chain("myparachain")
                     .with_chain_spec_path("/path/to/my/chain/spec.json")
+                    .with_registration_strategy(RegistrationStrategy::UsingExtrinsic)
+                    .onboard_as_parachain(false)
                     .with_default_db_snapshot("https://storage.com/path/to/db_snapshot.tgz")
                     .with_collator(|collator| {
                         collator

--- a/crates/configuration/src/network.rs
+++ b/crates/configuration/src/network.rs
@@ -283,9 +283,8 @@ impl NetworkConfigBuilder<WithRelaychain> {
 mod tests {
     use std::fs;
 
-    use crate::parachain::RegistrationStrategy;
-
     use super::*;
+    use crate::parachain::RegistrationStrategy;
 
     #[test]
     fn network_config_builder_should_succeeds_and_returns_a_network_config() {

--- a/crates/configuration/src/parachain.rs
+++ b/crates/configuration/src/parachain.rs
@@ -43,6 +43,7 @@ pub struct ParachainConfig {
     chain: Option<Chain>,
     #[serde(flatten)]
     registration_strategy: Option<RegistrationStrategy>,
+    #[serde(skip_serializing_if = "super::utils::is_true")]
     onboard_as_parachain: bool,
     #[serde(rename = "balance")]
     initial_balance: U128,
@@ -998,5 +999,17 @@ mod tests {
             errors.get(4).unwrap().to_string(),
             "parachain[2000].collators['collator2'].image: 'invalid.image' doesn't match regex '^([ip]|[hostname]/)?[tag_name]:[tag_version]?$'"
         );
+    }
+
+    #[test]
+    fn onboard_as_parachain_should_default_to_true() {
+        let config = ParachainConfigBuilder::new(Default::default())
+            .with_id(2000)
+            .with_chain("myparachain")
+            .with_collator(|collator| collator.with_name("collator"))
+            .build()
+            .unwrap();
+
+        assert!(config.onboard_as_parachain());
     }
 }

--- a/crates/configuration/src/parachain.rs
+++ b/crates/configuration/src/parachain.rs
@@ -43,6 +43,7 @@ pub struct ParachainConfig {
     chain: Option<Chain>,
     #[serde(flatten)]
     registration_strategy: Option<RegistrationStrategy>,
+    onboard_as_parachain: bool,
     #[serde(rename = "balance")]
     initial_balance: U128,
     default_command: Option<Command>,
@@ -78,6 +79,11 @@ impl ParachainConfig {
     /// The registration strategy for the parachain.
     pub fn registration_strategy(&self) -> Option<&RegistrationStrategy> {
         self.registration_strategy.as_ref()
+    }
+
+    /// Whether the parachain should be onboarded or stay a parathread
+    pub fn onboard_as_parachain(&self) -> bool {
+        self.onboard_as_parachain
     }
 
     /// The initial balance of the parachain account.
@@ -173,6 +179,7 @@ impl Default for ParachainConfigBuilder<Initial> {
                 id: 100,
                 chain: None,
                 registration_strategy: Some(RegistrationStrategy::InGenesis),
+                onboard_as_parachain: true,
                 initial_balance: 2_000_000_000_000.into(),
                 default_command: None,
                 default_image: None,
@@ -271,6 +278,18 @@ impl ParachainConfigBuilder<WithId> {
         Self::transition(
             ParachainConfig {
                 registration_strategy: Some(strategy),
+                ..self.config
+            },
+            self.validation_context,
+            self.errors,
+        )
+    }
+
+    /// Set whether the parachain should be onboarded or stay a parathread. Default is ```true```.
+    pub fn onboard_as_parachain(self, choice: bool) -> Self {
+        Self::transition(
+            ParachainConfig {
+                onboard_as_parachain: choice,
                 ..self.config
             },
             self.validation_context,
@@ -605,6 +624,7 @@ mod tests {
             .with_id(1000)
             .with_chain("mychainname")
             .with_registration_strategy(RegistrationStrategy::UsingExtrinsic)
+            .onboard_as_parachain(false)
             .with_initial_balance(100_000_042)
             .with_default_image("myrepo:myimage")
             .with_default_command("default_command")
@@ -656,6 +676,7 @@ mod tests {
             parachain_config.registration_strategy().unwrap(),
             &RegistrationStrategy::UsingExtrinsic
         );
+        assert!(!parachain_config.onboard_as_parachain());
         assert_eq!(parachain_config.initial_balance(), 100_000_042);
         assert_eq!(
             parachain_config.default_command().unwrap().as_str(),

--- a/crates/configuration/src/utils.rs
+++ b/crates/configuration/src/utils.rs
@@ -1,3 +1,3 @@
 pub fn is_true(value: &bool) -> bool {
-   *value 
+    *value
 }

--- a/crates/configuration/src/utils.rs
+++ b/crates/configuration/src/utils.rs
@@ -1,0 +1,3 @@
+pub fn is_true(value: &bool) -> bool {
+   *value 
+}

--- a/crates/configuration/testing/snapshots/0001-big-network.toml
+++ b/crates/configuration/testing/snapshots/0001-big-network.toml
@@ -64,7 +64,6 @@ balance = 1000000000
 id = 2000
 chain = "myotherparachain"
 add_to_genesis = true
-onboard_as_parachain = true
 balance = 2000000000000
 chain_spec_path = "/path/to/my/other/chain/spec.json"
 cumulus_based = true

--- a/crates/configuration/testing/snapshots/0001-big-network.toml
+++ b/crates/configuration/testing/snapshots/0001-big-network.toml
@@ -32,7 +32,8 @@ balance = 2000000000000
 [[parachains]]
 id = 1000
 chain = "myparachain"
-add_to_genesis = true
+register_para = true
+onboard_as_parachain = false
 balance = 2000000000000
 default_db_snapshot = "https://storage.com/path/to/db_snapshot.tgz"
 chain_spec_path = "/path/to/my/chain/spec.json"
@@ -63,6 +64,7 @@ balance = 1000000000
 id = 2000
 chain = "myotherparachain"
 add_to_genesis = true
+onboard_as_parachain = true
 balance = 2000000000000
 chain_spec_path = "/path/to/my/other/chain/spec.json"
 cumulus_based = true

--- a/crates/configuration/testing/snapshots/0002-overridden-defaults.toml
+++ b/crates/configuration/testing/snapshots/0002-overridden-defaults.toml
@@ -50,7 +50,6 @@ cpu = "5Gi"
 id = 1000
 chain = "myparachain"
 add_to_genesis = true
-onboard_as_parachain = true
 balance = 2000000000000
 default_command = "my-default-command"
 default_image = "mydefaultimage:latest"

--- a/crates/configuration/testing/snapshots/0002-overridden-defaults.toml
+++ b/crates/configuration/testing/snapshots/0002-overridden-defaults.toml
@@ -50,6 +50,7 @@ cpu = "5Gi"
 id = 1000
 chain = "myparachain"
 add_to_genesis = true
+onboard_as_parachain = true
 balance = 2000000000000
 default_command = "my-default-command"
 default_image = "mydefaultimage:latest"


### PR DESCRIPTION
The field ```onboard_as_parachain``` is missing on the ParachainConfig, which enables the user to tells if he wants the registered parathread (using genesis or extrinsic at spawn time) to be promoted to a parachain.

By default this value is true, hence skipped in the dump. 