### PR TITLE
Remove #[derive(Debug)]

### DIFF
--- a/crates/configuration/src/global_settings.rs
+++ b/crates/configuration/src/global_settings.rs
@@ -44,7 +44,6 @@ impl GlobalSettings {
 }
 
 /// A global settings builder, used to build [`GlobalSettings`] declaratively with fields validation.
-#[derive(Debug)]
 pub struct GlobalSettingsBuilder {
     config: GlobalSettings,
     errors: Vec<anyhow::Error>,

--- a/crates/configuration/src/hrmp_channel.rs
+++ b/crates/configuration/src/hrmp_channel.rs
@@ -42,7 +42,6 @@ states! {
 }
 
 /// HRMP channel configuration builder, used to build an [`HrmpChannelConfig`] declaratively with fields validation.
-#[derive(Debug)]
 pub struct HrmpChannelConfigBuilder<State> {
     config: HrmpChannelConfig,
     _state: PhantomData<State>,

--- a/crates/configuration/src/network.rs
+++ b/crates/configuration/src/network.rs
@@ -132,7 +132,6 @@ states! {
 ///
 /// assert!(network_config.is_ok())
 /// ```
-#[derive(Debug)]
 pub struct NetworkConfigBuilder<State> {
     config: NetworkConfig,
     validation_context: Rc<RefCell<ValidationContext>>,

--- a/crates/configuration/src/parachain.rs
+++ b/crates/configuration/src/parachain.rs
@@ -165,7 +165,6 @@ states! {
 }
 
 /// A parachain configuration builder, used to build a [`ParachainConfig`] declaratively with fields validation.
-#[derive(Debug)]
 pub struct ParachainConfigBuilder<S> {
     config: ParachainConfig,
     validation_context: Rc<RefCell<ValidationContext>>,

--- a/crates/configuration/src/relaychain.rs
+++ b/crates/configuration/src/relaychain.rs
@@ -87,7 +87,6 @@ states! {
 }
 
 /// A relay chain configuration builder, used to build a [`RelaychainConfig`] declaratively with fields validation.
-#[derive(Debug)]
 pub struct RelaychainConfigBuilder<State> {
     config: RelaychainConfig,
     validation_context: Rc<RefCell<ValidationContext>>,

--- a/crates/configuration/src/shared/node.rs
+++ b/crates/configuration/src/shared/node.rs
@@ -234,7 +234,6 @@ states! {
 }
 
 /// A node configuration builder, used to build a [`NodeConfig`] declaratively with fields validation.
-#[derive(Debug)]
 pub struct NodeConfigBuilder<S> {
     config: NodeConfig,
     validation_context: Rc<RefCell<ValidationContext>>,

--- a/crates/support/src/fs/local_file.rs
+++ b/crates/support/src/fs/local_file.rs
@@ -4,7 +4,6 @@ use std::{
     process::Stdio,
 };
 
-#[derive(Debug)]
 pub struct LocalFile(File);
 
 impl From<File> for LocalFile {


### PR DESCRIPTION
Remove all `#[derive(Debug)]` from codebase
(Fixes a lot of the coverage report)