### PR TITLE
Expose subxt onclineclient / rpc

### DIFF
--- a/crates/examples/examples/simple_network_example.rs
+++ b/crates/examples/examples/simple_network_example.rs
@@ -14,11 +14,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let pm = OsProcessManager;
     let provider = NativeProvider::new(fs.clone(), pm);
     let orchestrator = Orchestrator::new(fs, provider);
-    orchestrator.spawn(config).await?;
+    let network = orchestrator.spawn(config).await?;
     println!("🚀🚀🚀🚀 network deployed");
-    // For now let just loop....
-    #[allow(clippy::empty_loop)]
-    loop {}
 
-    // Ok(())
+    let client = network.get_node("alice").unwrap().client();
+    let mut blocks = client.blocks().subscribe_finalized().await?;
+    while let Some(block) = blocks.next().await {
+        println!("Block #{}", block?.header().number);
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
just wanted to throw a quick implementation that exposes the OnclineClient on the node.
This would make the sdk super useful to enable cross chain e2e tests in ink!