### PR TITLE
Expose Top level API through zombienet-sdk crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+  "crates/sdk",
   "crates/examples",
   "crates/support",
   "crates/configuration",

--- a/crates/examples/examples/simple_network_example.rs
+++ b/crates/examples/examples/simple_network_example.rs
@@ -1,21 +1,13 @@
-// use std::time::Duration;
-
-use configuration::NetworkConfig;
 use futures::stream::StreamExt;
-use orchestrator::Orchestrator;
-use provider::NativeProvider;
-use support::{fs::local::LocalFileSystem, process::os::OsProcessManager};
+use zombienet_sdk::{NetworkConfig, Spawner};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = NetworkConfig::load_from_toml("./crates/examples/examples/0001-simple.toml")
-        .expect("errored?");
+    let network = NetworkConfig::load_from_toml("./crates/examples/examples/0001-simple.toml")
+        .expect("errored?")
+        .spawn_native()
+        .await?;
 
-    let fs = LocalFileSystem;
-    let pm = OsProcessManager;
-    let provider = NativeProvider::new(fs.clone(), pm);
-    let orchestrator = Orchestrator::new(fs, provider);
-    let network = orchestrator.spawn(config).await?;
     println!("🚀🚀🚀🚀 network deployed");
 
     let client = network

--- a/crates/examples/examples/simple_network_example.rs
+++ b/crates/examples/examples/simple_network_example.rs
@@ -1,5 +1,5 @@
 use futures::stream::StreamExt;
-use zombienet_sdk::{NetworkConfig, Spawner};
+use zombienet_sdk::{NetworkConfig, NetworkConfigExt};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/examples/examples/small_network.rs
+++ b/crates/examples/examples/small_network.rs
@@ -1,4 +1,4 @@
-use configuration::NetworkConfigBuilder;
+use zombienet_sdk::NetworkConfigBuilder;
 
 fn main() {
     let config = NetworkConfigBuilder::new()

--- a/crates/examples/examples/small_network_with_default.rs
+++ b/crates/examples/examples/small_network_with_default.rs
@@ -1,11 +1,8 @@
-use configuration::NetworkConfigBuilder;
-use orchestrator::{AddNodeOpts, Orchestrator};
-use provider::NativeProvider;
-use support::{fs::local::LocalFileSystem, process::os::OsProcessManager};
+use zombienet_sdk::{AddNodeOpts, NetworkConfigBuilder, Spawner};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = NetworkConfigBuilder::new()
+    let mut network = NetworkConfigBuilder::new()
         .with_relaychain(|r| {
             r.with_chain("rococo-local")
                 .with_default_command("polkadot")
@@ -18,13 +15,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .with_collator(|n| n.with_name("collator").with_command("polkadot-parachain"))
         })
         .build()
-        .unwrap();
+        .unwrap()
+        .spawn_native()
+        .await?;
 
-    let fs = LocalFileSystem;
-    let pm = OsProcessManager;
-    let provider = NativeProvider::new(fs.clone(), pm);
-    let orchestrator = Orchestrator::new(fs, provider);
-    let mut network = orchestrator.spawn(config).await?;
     println!("🚀🚀🚀🚀 network deployed");
     // add  a new node
     let opts = AddNodeOpts {
@@ -36,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // TODO: add check to ensure if unique
     network.add_node("new1", opts, None).await?;
 
-    // Example of some opertions that you can do
+    // Example of some operations that you can do
     // with `nodes` (e.g pause, resume, restart)
 
     // Get a ref to the node

--- a/crates/examples/examples/small_network_with_default.rs
+++ b/crates/examples/examples/small_network_with_default.rs
@@ -1,4 +1,4 @@
-use zombienet_sdk::{AddNodeOpts, NetworkConfigBuilder, Spawner};
+use zombienet_sdk::{AddNodeOpts, NetworkConfigBuilder, NetworkConfigExt};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/examples/examples/small_network_with_para.rs
+++ b/crates/examples/examples/small_network_with_para.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use zombienet_sdk::{AddNodeOpts, NetworkConfigBuilder, RegistrationStrategy, Spawner};
+use zombienet_sdk::{AddNodeOpts, NetworkConfigBuilder, NetworkConfigExt, RegistrationStrategy};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/examples/examples/small_network_with_para.rs
+++ b/crates/examples/examples/small_network_with_para.rs
@@ -1,13 +1,10 @@
 use std::time::Duration;
 
-use configuration::{NetworkConfigBuilder, RegistrationStrategy};
-use orchestrator::{AddNodeOpts, Orchestrator};
-use provider::NativeProvider;
-use support::{fs::local::LocalFileSystem, process::os::OsProcessManager};
+use zombienet_sdk::{AddNodeOpts, NetworkConfigBuilder, RegistrationStrategy, Spawner};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = NetworkConfigBuilder::new()
+    let mut network = NetworkConfigBuilder::new()
         .with_relaychain(|r| {
             r.with_chain("rococo-local")
                 .with_default_command("polkadot")
@@ -21,13 +18,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .with_collator(|n| n.with_name("collator").with_command("polkadot-parachain"))
         })
         .build()
-        .unwrap();
+        .unwrap()
+        .spawn_native()
+        .await?;
 
-    let fs = LocalFileSystem;
-    let pm = OsProcessManager;
-    let provider = NativeProvider::new(fs.clone(), pm);
-    let orchestrator = Orchestrator::new(fs, provider);
-    let mut network = orchestrator.spawn(config).await?;
     println!("🚀🚀🚀🚀 network deployed");
     // add  a new node
     let opts = AddNodeOpts {
@@ -41,7 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     tokio::time::sleep(Duration::from_secs(2)).await;
 
-    // Example of some opertions that you can do
+    // Example of some operations that you can do
     // with `nodes` (e.g pause, resume, restart)
 
     tokio::time::sleep(Duration::from_secs(10)).await;

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -1,9 +1,9 @@
 // TODO(Javier): Remove when we implement the logic in the orchestrator to spawn with the provider.
 #![allow(dead_code)]
 
-mod errors;
+pub mod errors;
 mod generators;
-mod network;
+pub mod network;
 mod network_helper;
 mod network_spec;
 mod shared;

--- a/crates/orchestrator/src/network.rs
+++ b/crates/orchestrator/src/network.rs
@@ -182,13 +182,22 @@ impl<T: FileSystem> Network<T> {
     // deregister and stop the collator?
     // remove_parachain()
 
-    pub fn get_node(&self, node_name: impl Into<String>) -> Result<&NetworkNode, anyhow::Error> {
-        let node_name = node_name.into();
-        if let Some(node) = self.nodes_by_name.get(&node_name) {
-            Ok(node)
-        } else {
-            Err(anyhow::anyhow!("can't find the node!"))
+    pub fn get_node(&self, name: impl Into<String>) -> Result<&NetworkNode, anyhow::Error> {
+        let name = &name.into();
+        if let Some(node) = self.nodes_by_name.get(name) {
+            return Ok(node);
         }
+
+        let list = self
+            .nodes_by_name
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        Err(anyhow::anyhow!(
+            "can't find node with name: {name:?}, should be one of {list}"
+        ))
     }
 
     pub fn nodes(&self) -> Vec<&NetworkNode> {

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -86,7 +86,7 @@ pub trait ProviderNamespace {
     async fn static_setup(&self) -> Result<(), ProviderError>;
 }
 
-pub type DynNamespace = Arc<dyn ProviderNamespace>;
+pub type DynNamespace = Arc<dyn ProviderNamespace + Send + Sync>;
 
 type ExecutionResult = Result<String, (ExitStatus, String)>;
 

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
-name = "examples"
+name = "zombienet-sdk"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zombienet-sdk = { path = "../sdk" }
+configuration = { path = "../configuration" }
+orchestrator = { path = "../orchestrator" }
+provider = { path = "../provider" }
+support = { path = "../support" }
+async-trait = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
 subxt = { workspace = true }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1,0 +1,20 @@
+use async_trait::async_trait;
+pub use configuration::{NetworkConfig, NetworkConfigBuilder, RegistrationStrategy};
+pub use orchestrator::{errors::OrchestratorError, network::Network, AddNodeOpts, Orchestrator};
+use provider::NativeProvider;
+use support::{fs::local::LocalFileSystem, process::os::OsProcessManager};
+
+#[async_trait]
+pub trait Spawner {
+    /// Spawns a network using the native provider.
+    async fn spawn_native(self) -> Result<Network<LocalFileSystem>, OrchestratorError>;
+}
+
+#[async_trait]
+impl Spawner for NetworkConfig {
+    async fn spawn_native(self) -> Result<Network<LocalFileSystem>, OrchestratorError> {
+        let provider = NativeProvider::new(LocalFileSystem {}, OsProcessManager {});
+        let orchestrator = Orchestrator::new(LocalFileSystem {}, provider);
+        orchestrator.spawn(self).await
+    }
+}

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -5,13 +5,13 @@ use provider::NativeProvider;
 use support::{fs::local::LocalFileSystem, process::os::OsProcessManager};
 
 #[async_trait]
-pub trait Spawner {
+pub trait NetworkConfigExt {
     /// Spawns a network using the native provider.
     async fn spawn_native(self) -> Result<Network<LocalFileSystem>, OrchestratorError>;
 }
 
 #[async_trait]
-impl Spawner for NetworkConfig {
+impl NetworkConfigExt for NetworkConfig {
     async fn spawn_native(self) -> Result<Network<LocalFileSystem>, OrchestratorError> {
         let provider = NativeProvider::new(LocalFileSystem {}, OsProcessManager {});
         let orchestrator = Orchestrator::new(LocalFileSystem {}, provider);

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -7,6 +7,17 @@ use support::{fs::local::LocalFileSystem, process::os::OsProcessManager};
 #[async_trait]
 pub trait NetworkConfigExt {
     /// Spawns a network using the native provider.
+    ///
+    /// # Example:
+    /// ```rust
+    /// # use zombienet_sdk::{NetworkConfig, NetworkConfigExt};
+    /// # async fn example() -> Result<(), zombienet_sdk::OrchestratorError> {
+    /// let network = NetworkConfig::load_from_toml("config.toml")?
+    ///     .spawn_native()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     async fn spawn_native(self) -> Result<Network<LocalFileSystem>, OrchestratorError>;
 }
 


### PR DESCRIPTION
Following up on take 1 https://github.com/paritytech/zombienet-sdk/pull/124

Apart from better logs, I realize that one of the only thing missing now for us to start consuming this project  is a top level package available (with it's dependencies) on crates.io. This PR serves mainly as a discussion point to get there.
It would be great if we could publish an early version (0.0.1?) on crates.io so that we can start using this asap.


 