### PR TITLE
Fix: paras spec file name

### DIFF
--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -73,6 +73,10 @@ impl ChainSpec {
         }
     }
 
+    pub(crate) fn chain_spec_name(&self) -> &str {
+        self.chain_spec_name.as_ref()
+    }
+
     pub(crate) fn chain_name(&self) -> Option<&str> {
         self.chain_name.as_deref()
     }

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -289,11 +289,7 @@ where
                 // add the spec to global files to inject
                 let spec_name = chain_spec.chain_spec_name();
                 para_files_to_inject.push(TransferedFile {
-                    local_path: PathBuf::from(format!(
-                        "{}/{}.json",
-                        ns.base_dir().to_string_lossy(),
-                        spec_name
-                    )),
+                    local_path: ns.base_dir().join(format!("{}.json", spec_name)),
                     remote_path: PathBuf::from(format!("/cfg/{}.json", para.id)),
                 });
 

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -279,9 +279,24 @@ where
 
         // spawn paras
         for para in network_spec.parachains.iter() {
+            // global files to include for this parachain
+            let mut para_files_to_inject = global_files_to_inject.clone();
+
             // parachain id is used for the keystore
             let parachain_id = if let Some(chain_spec) = para.chain_spec.as_ref() {
                 let id = chain_spec.read_chain_id(&scoped_fs).await?;
+
+                // add the spec to global files to inject
+                let spec_name = chain_spec.chain_spec_name();
+                para_files_to_inject.push(TransferedFile {
+                    local_path: PathBuf::from(format!(
+                        "{}/{}.json",
+                        ns.base_dir().to_string_lossy(),
+                        spec_name
+                    )),
+                    remote_path: PathBuf::from(format!("/cfg/{}.json", para.id)),
+                });
+
                 let raw_path = chain_spec
                     .raw_path()
                     .ok_or(OrchestratorError::InvariantError(
@@ -311,17 +326,6 @@ where
                 bootnodes_addr: &vec![],
                 ..ctx.clone()
             };
-            let mut para_files_to_inject = global_files_to_inject.clone();
-            if para.is_cumulus_based {
-                para_files_to_inject.push(TransferedFile {
-                    local_path: PathBuf::from(format!(
-                        "{}/{}.json",
-                        ns.base_dir().to_string_lossy(),
-                        para.id
-                    )),
-                    remote_path: PathBuf::from(format!("/cfg/{}.json", para.id)),
-                });
-            }
 
             let spawning_tasks = para
                 .collators

--- a/crates/orchestrator/src/spawner.rs
+++ b/crates/orchestrator/src/spawner.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
-use anyhow::Context;
 
+use anyhow::Context;
 use provider::{
     constants::LOCALHOST,
     types::{SpawnNodeOptions, TransferedFile},
@@ -151,7 +151,10 @@ where
     node.rpc_port.drop_listener();
     node.prometheus_port.drop_listener();
 
-    let err_context = format!("Failed to spawn node: {} with opts: {:#?}", node.name, spawn_ops);
+    let err_context = format!(
+        "Failed to spawn node: {} with opts: {:#?}",
+        node.name, spawn_ops
+    );
     let running_node = ctx.ns.spawn_node(spawn_ops).await.context(err_context)?;
 
     let ws_uri = format!("ws://{}:{}", LOCALHOST, node.rpc_port.0);

--- a/crates/orchestrator/src/spawner.rs
+++ b/crates/orchestrator/src/spawner.rs
@@ -151,11 +151,12 @@ where
     node.rpc_port.drop_listener();
     node.prometheus_port.drop_listener();
 
-    let err_context = format!(
-        "Failed to spawn node: {} with opts: {:#?}",
-        node.name, spawn_ops
-    );
-    let running_node = ctx.ns.spawn_node(spawn_ops).await.context(err_context)?;
+    let running_node = ctx.ns.spawn_node(&spawn_ops).await.with_context(|| {
+        format!(
+            "Failed to spawn node: {} with opts: {:#?}",
+            node.name, spawn_ops
+        )
+    })?;
 
     let ws_uri = format!("ws://{}:{}", LOCALHOST, node.rpc_port.0);
     let prometheus_uri = format!("http://{}:{}/metrics", LOCALHOST, node.prometheus_port.0);

--- a/crates/orchestrator/src/spawner.rs
+++ b/crates/orchestrator/src/spawner.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use anyhow::Context;
 
 use provider::{
     constants::LOCALHOST,
@@ -150,7 +151,8 @@ where
     node.rpc_port.drop_listener();
     node.prometheus_port.drop_listener();
 
-    let running_node = ctx.ns.spawn_node(spawn_ops).await?;
+    let err_context = format!("Failed to spawn node: {} with opts: {:#?}", node.name, spawn_ops);
+    let running_node = ctx.ns.spawn_node(spawn_ops).await.context(err_context)?;
 
     let ws_uri = format!("ws://{}:{}", LOCALHOST, node.rpc_port.0);
     let prometheus_uri = format!("http://{}:{}/metrics", LOCALHOST, node.prometheus_port.0);

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -77,7 +77,7 @@ pub trait ProviderNamespace {
 
     async fn nodes(&self) -> HashMap<String, DynNode>;
 
-    async fn spawn_node(&self, options: SpawnNodeOptions) -> Result<DynNode, ProviderError>;
+    async fn spawn_node(&self, options: &SpawnNodeOptions) -> Result<DynNode, ProviderError>;
 
     async fn generate_files(&self, options: GenerateFilesOptions) -> Result<(), ProviderError>;
 

--- a/crates/provider/src/native/node.rs
+++ b/crates/provider/src/native/node.rs
@@ -318,7 +318,7 @@ mod tests {
 
         // spawn dummy node
         let node = namespace
-            .spawn_node(SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
+            .spawn_node(&SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
             .await
             .unwrap();
 
@@ -363,7 +363,7 @@ mod tests {
 
         // spawn dummy node
         let node = namespace
-            .spawn_node(SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
+            .spawn_node(&SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
             .await
             .unwrap();
 
@@ -431,7 +431,7 @@ mod tests {
 
         // spawn dummy node
         let node = namespace
-            .spawn_node(SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
+            .spawn_node(&SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
             .await
             .unwrap();
 
@@ -474,7 +474,7 @@ mod tests {
 
         // spawn dummy node
         let node = namespace
-            .spawn_node(SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
+            .spawn_node(&SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
             .await
             .unwrap();
 
@@ -509,7 +509,7 @@ mod tests {
 
         // spawn dummy node
         let node = namespace
-            .spawn_node(SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
+            .spawn_node(&SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
             .await
             .unwrap();
 
@@ -556,7 +556,7 @@ mod tests {
 
         // spawn dummy node
         let node = namespace
-            .spawn_node(SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
+            .spawn_node(&SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
             .await
             .unwrap();
 
@@ -611,7 +611,7 @@ mod tests {
 
         // spawn dummy node
         let node = namespace
-            .spawn_node(SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
+            .spawn_node(&SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
             .await
             .unwrap();
 
@@ -652,7 +652,7 @@ mod tests {
 
         // spawn dummy node
         let node = namespace
-            .spawn_node(SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
+            .spawn_node(&SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
             .await
             .unwrap();
 
@@ -711,7 +711,7 @@ mod tests {
 
         // spawn dummy node
         let node = namespace
-            .spawn_node(SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
+            .spawn_node(&SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
             .await
             .unwrap();
 
@@ -808,7 +808,7 @@ mod tests {
 
         // spawn dummy node
         let node = namespace
-            .spawn_node(SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
+            .spawn_node(&SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
             .await
             .unwrap();
 
@@ -844,7 +844,7 @@ mod tests {
 
         // spawn dummy node
         let node = namespace
-            .spawn_node(SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
+            .spawn_node(&SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
             .await
             .unwrap();
 
@@ -966,7 +966,7 @@ mod tests {
 
         // spawn dummy node
         let node = namespace
-            .spawn_node(SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
+            .spawn_node(&SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
             .await
             .unwrap();
 
@@ -1012,7 +1012,7 @@ mod tests {
 
         let node = namespace
             .spawn_node(
-                SpawnNodeOptions::new("mynode", "/path/to/my/node_binary")
+                &SpawnNodeOptions::new("mynode", "/path/to/my/node_binary")
                     .args(vec![
                         "-flag1",
                         "--flag2",
@@ -1168,7 +1168,7 @@ mod tests {
 
         // spawn dummy node
         let node = namespace
-            .spawn_node(SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
+            .spawn_node(&SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
             .await
             .unwrap();
 
@@ -1203,7 +1203,7 @@ mod tests {
 
         // spawn dummy node
         let node = namespace
-            .spawn_node(SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
+            .spawn_node(&SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
             .await
             .unwrap();
 
@@ -1280,7 +1280,7 @@ mod tests {
 
         // spawn dummy node
         let node = namespace
-            .spawn_node(SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
+            .spawn_node(&SpawnNodeOptions::new("mynode", "/path/to/my/node_binary"))
             .await
             .unwrap();
 

--- a/crates/provider/src/shared/types.rs
+++ b/crates/provider/src/shared/types.rs
@@ -18,6 +18,7 @@ impl ProviderCapabilities {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct SpawnNodeOptions {
     pub name: String,
     pub program: String,


### PR DESCRIPTION
Fix parachain spec filename (local) to use when we spawn collators. Also, adding `Context` to spawner to improve error reporting.

cc @pgherveou 