### PR TITLE
feat: Add `pjs-rs` calls for `Network::Node`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ libp2p = { version = "0.52" }
 subxt = "0.32.0"
 subxt-signer = { version = "0.32.0", features = ["subxt"]}
 tracing = "0.1.35"
+pjs-rs = "0.1.2"
 
 # Zombienet workspace crates:
 support = { package = "zombienet-support", version = "0.1.0-alpha.0", path = "crates/support" }

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -11,3 +11,4 @@ tokio = { workspace = true }
 futures = { workspace = true }
 subxt = { workspace = true }
 tracing-subscriber = "0.3"
+serde_json = { workspace = true }

--- a/crates/examples/examples/pjs.rs
+++ b/crates/examples/examples/pjs.rs
@@ -1,6 +1,5 @@
-use serde_json::json;
-
 use futures::stream::StreamExt;
+use serde_json::json;
 use zombienet_sdk::{NetworkConfigBuilder, NetworkConfigExt};
 
 #[tokio::main]
@@ -46,7 +45,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("parachains registered: {:?}", paras);
 
     // run pjs with file
-    let _ = alice.pjs_file("./examples/pjs_transfer.js", vec![json!("//Alice")]).await?;
+    let _ = alice
+        .pjs_file("./examples/pjs_transfer.js", vec![json!("//Alice")])
+        .await?;
 
     Ok(())
 }

--- a/crates/examples/examples/pjs.rs
+++ b/crates/examples/examples/pjs.rs
@@ -1,0 +1,52 @@
+use serde_json::json;
+
+use futures::stream::StreamExt;
+use zombienet_sdk::{NetworkConfigBuilder, NetworkConfigExt};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+    let network = NetworkConfigBuilder::new()
+        .with_relaychain(|r| {
+            r.with_chain("rococo-local")
+                .with_default_command("polkadot")
+                .with_node(|node| node.with_name("alice"))
+                .with_node(|node| node.with_name("bob"))
+        })
+        .with_parachain(|p| {
+            p.with_id(100)
+                .cumulus_based(true)
+                .with_collator(|n| n.with_name("collator").with_command("polkadot-parachain"))
+        })
+        .build()
+        .unwrap()
+        .spawn_native()
+        .await?;
+
+    println!("🚀🚀🚀🚀 network deployed");
+
+    let alice = network.get_node("alice")?;
+    let client = alice.client::<subxt::PolkadotConfig>().await?;
+
+    // wait 2 blocks
+    let mut blocks = client.blocks().subscribe_finalized().await?.take(2);
+
+    while let Some(block) = blocks.next().await {
+        println!("Block #{}", block?.header().number);
+    }
+
+    // run pjs with code
+    let query_paras = r#"
+    const parachains: number[] = (await api.query.paras.parachains()) || [];
+    return parachains.toJSON()
+    "#;
+
+    let paras = alice.pjs(query_paras, vec![]).await??;
+
+    println!("parachains registered: {:?}", paras);
+
+    // run pjs with file
+    let _ = alice.pjs_file("./examples/pjs_transfer.js", vec![json!("//Alice")]).await?;
+
+    Ok(())
+}

--- a/crates/examples/examples/pjs_transfer.js
+++ b/crates/examples/examples/pjs_transfer.js
@@ -1,0 +1,32 @@
+const seed = arguments[0];
+
+await utilCrypto.cryptoWaitReady();
+const k = new keyring.Keyring({ type: "sr25519" });
+const signer = k.addFromUri(seed);
+
+// Make a transfer from Alice to Bob and listen to system events.
+// You need to be connected to a development chain for this example to work.
+const ALICE = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+const BOB = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty';
+
+// Get a random number between 1 and 100000
+const randomAmount = Math.floor((Math.random() * 100000) + 1);
+
+// Create a extrinsic, transferring randomAmount units to Bob.
+const transferAllowDeath = api.tx.balances.transferAllowDeath(BOB, randomAmount);
+
+return new Promise(async (resolve, _reject) => {
+    // Sign and Send the transaction
+    const unsub = await transferAllowDeath.signAndSend(signer, ({ events = [], status }) => {
+        if (status.isInBlock) {
+            console.log('Successful transfer of ' + randomAmount + ' with hash ' + status.asInBlock.toHex());
+            return resolve();
+        } else {
+            console.log('Status of transfer: ' + status.type);
+        }
+
+        events.forEach(({ phase, event: { data, method, section } }) => {
+            console.log(phase.toString() + ' : ' + section + '.' + method + ' ' + data.toString());
+        });
+    });
+});

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -28,6 +28,7 @@ subxt = { workspace = true }
 subxt-signer = { workspace = true }
 reqwest = { workspace = true }
 tracing = { workspace = true }
+pjs-rs = { workspace = true }
 
 # Zombienet deps
 configuration = { workspace = true }

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -459,4 +459,4 @@ pub enum ZombieRole {
 
 // re-export
 pub use network::{AddCollatorOptions, AddNodeOptions};
-pub use shared::types::PjsSuccessResult;
+pub use shared::types::PjsResult;

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -459,3 +459,4 @@ pub enum ZombieRole {
 
 // re-export
 pub use network::{AddCollatorOptions, AddNodeOptions};
+pub use shared::types::PjsSuccessResult;

--- a/crates/orchestrator/src/network/node.rs
+++ b/crates/orchestrator/src/network/node.rs
@@ -224,5 +224,6 @@ fn pjs_build_template(ws_uri: &str, content: &str, args: Vec<serde_json::Value>)
 // execute in an isolated thread.
 #[tokio::main(flavor = "current_thread")]
 async fn pjs_inner(code: String) -> Result<ReturnValue, anyhow::Error> {
-    Ok(pjs_rs::run_ts_code(code, None).await?)
+    // Arguments are already encoded in the code built from the template.
+    pjs_rs::run_ts_code(code, None).await
 }

--- a/crates/orchestrator/src/network/node.rs
+++ b/crates/orchestrator/src/network/node.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration, thread, path::Path};
+use std::{path::Path, sync::Arc, thread, time::Duration};
 
 use anyhow::anyhow;
 use pjs_rs::ReturnValue;
@@ -73,11 +73,16 @@ impl NetworkNode {
     /// The code will be run in a wrapper similat to the `javascript` developer tab
     /// of polkadot.js apps. The returning value is represented as [PjsSuccessResult] enum, to allow
     /// to communicate that the execution was succeful but the returning value can be deserialized as [serde_json::Value].
-    pub async fn pjs(&self, code: impl AsRef<str>, args: Vec<serde_json::Value>) -> Result<PjsSuccessResult, anyhow::Error> {
+    pub async fn pjs(
+        &self,
+        code: impl AsRef<str>,
+        args: Vec<serde_json::Value>,
+    ) -> Result<PjsSuccessResult, anyhow::Error> {
         let code = pjs_build_template(self.ws_uri(), code.as_ref(), args);
-        let value = match thread::spawn(|| {
-            pjs_inner(code)
-        }).join().map_err(|_| anyhow!("[pjs] Thread panicked"))?? {
+        let value = match thread::spawn(|| pjs_inner(code))
+            .join()
+            .map_err(|_| anyhow!("[pjs] Thread panicked"))??
+        {
             ReturnValue::Deserialized(val) => PjsSuccessResult::Value(val),
             ReturnValue::CantDeserialize(msg) => PjsSuccessResult::DeserializeErrorMsg(msg),
         };
@@ -90,12 +95,17 @@ impl NetworkNode {
     /// The content of the file will be run in a wrapper similat to the `javascript` developer tab
     /// of polkadot.js apps. The returning value is represented as [PjsSuccessResult] enum, to allow
     /// to communicate that the execution was succeful but the returning value can be deserialized as [serde_json::Value].
-    pub async fn pjs_file(&self, file: impl AsRef<Path>, args: Vec<serde_json::Value>) -> Result<PjsSuccessResult, anyhow::Error> {
+    pub async fn pjs_file(
+        &self,
+        file: impl AsRef<Path>,
+        args: Vec<serde_json::Value>,
+    ) -> Result<PjsSuccessResult, anyhow::Error> {
         let content = std::fs::read_to_string(file)?;
         let code = pjs_build_template(self.ws_uri(), content.as_ref(), args);
-        let value = match thread::spawn(|| {
-            pjs_inner(code)
-        }).join().map_err(|_| anyhow!("[pjs] Thread panicked"))?? {
+        let value = match thread::spawn(|| pjs_inner(code))
+            .join()
+            .map_err(|_| anyhow!("[pjs] Thread panicked"))??
+        {
             ReturnValue::Deserialized(val) => PjsSuccessResult::Value(val),
             ReturnValue::CantDeserialize(msg) => PjsSuccessResult::DeserializeErrorMsg(msg),
         };
@@ -193,7 +203,8 @@ impl std::fmt::Debug for NetworkNode {
 // Helper methods
 
 fn pjs_build_template(ws_uri: &str, content: &str, args: Vec<serde_json::Value>) -> String {
-    format!(r#"
+    format!(
+        r#"
     const {{ util, utilCrypto, keyring, types }} = pjs;
     ( async () => {{
         const api = await pjs.api.ApiPromise.create({{ provider: new pjs.api.WsProvider('{}') }});
@@ -202,7 +213,11 @@ fn pjs_build_template(ws_uri: &str, content: &str, args: Vec<serde_json::Value>)
         }};
         return await _run(api, utilCrypto, keyring, types, util, {});
     }})()
-    "#, ws_uri, content, json!(args))
+    "#,
+        ws_uri,
+        content,
+        json!(args)
+    )
 }
 
 // Since pjs-rs run a custom javascript runtime (using deno_core) we need to

--- a/crates/orchestrator/src/network/node.rs
+++ b/crates/orchestrator/src/network/node.rs
@@ -1,12 +1,14 @@
-use std::{sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration, thread, path::Path};
 
 use anyhow::anyhow;
+use pjs_rs::ReturnValue;
 use prom_metrics_parser::MetricMap;
 use provider::DynNode;
+use serde_json::json;
 use subxt::{backend::rpc::RpcClient, OnlineClient};
 use tokio::sync::RwLock;
 
-use crate::network_spec::node::NodeSpec;
+use crate::{network_spec::node::NodeSpec, PjsSuccessResult};
 
 #[derive(Clone)]
 pub struct NetworkNode {
@@ -64,6 +66,41 @@ impl NetworkNode {
         &self,
     ) -> Result<OnlineClient<Config>, subxt::Error> {
         OnlineClient::from_url(&self.ws_uri).await
+    }
+
+    /// Execute js/ts code inside [pjs_rs] custom runtime.
+    ///
+    /// The code will be run in a wrapper similat to the `javascript` developer tab
+    /// of polkadot.js apps. The returning value is represented as [PjsSuccessResult] enum, to allow
+    /// to communicate that the execution was succeful but the returning value can be deserialized as [serde_json::Value].
+    pub async fn pjs(&self, code: impl AsRef<str>, args: Vec<serde_json::Value>) -> Result<PjsSuccessResult, anyhow::Error> {
+        let code = pjs_build_template(self.ws_uri(), code.as_ref(), args);
+        let value = match thread::spawn(|| {
+            pjs_inner(code)
+        }).join().map_err(|_| anyhow!("[pjs] Thread panicked"))?? {
+            ReturnValue::Deserialized(val) => PjsSuccessResult::Value(val),
+            ReturnValue::CantDeserialize(msg) => PjsSuccessResult::DeserializeErrorMsg(msg),
+        };
+
+        Ok(value)
+    }
+
+    /// Execute js/ts file  inside [pjs_rs] custom runtime.
+    ///
+    /// The content of the file will be run in a wrapper similat to the `javascript` developer tab
+    /// of polkadot.js apps. The returning value is represented as [PjsSuccessResult] enum, to allow
+    /// to communicate that the execution was succeful but the returning value can be deserialized as [serde_json::Value].
+    pub async fn pjs_file(&self, file: impl AsRef<Path>, args: Vec<serde_json::Value>) -> Result<PjsSuccessResult, anyhow::Error> {
+        let content = std::fs::read_to_string(file)?;
+        let code = pjs_build_template(self.ws_uri(), content.as_ref(), args);
+        let value = match thread::spawn(|| {
+            pjs_inner(code)
+        }).join().map_err(|_| anyhow!("[pjs] Thread panicked"))?? {
+            ReturnValue::Deserialized(val) => PjsSuccessResult::Value(val),
+            ReturnValue::CantDeserialize(msg) => PjsSuccessResult::DeserializeErrorMsg(msg),
+        };
+
+        Ok(value)
     }
 
     /// Resume the node, this is implemented by resuming the
@@ -151,4 +188,26 @@ impl std::fmt::Debug for NetworkNode {
             .field("prometheus_uri", &self.prometheus_uri)
             .finish()
     }
+}
+
+// Helper methods
+
+fn pjs_build_template(ws_uri: &str, content: &str, args: Vec<serde_json::Value>) -> String {
+    format!(r#"
+    const {{ util, utilCrypto, keyring, types }} = pjs;
+    ( async () => {{
+        const api = await pjs.api.ApiPromise.create({{ provider: new pjs.api.WsProvider('{}') }});
+        const _run = async (api, hashing, keyring, types, util, arguments) => {{
+            {}
+        }};
+        return await _run(api, utilCrypto, keyring, types, util, {});
+    }})()
+    "#, ws_uri, content, json!(args))
+}
+
+// Since pjs-rs run a custom javascript runtime (using deno_core) we need to
+// execute in an isolated thread.
+#[tokio::main(flavor = "current_thread")]
+async fn pjs_inner(code: String) -> Result<ReturnValue, anyhow::Error> {
+    Ok(pjs_rs::run_ts_code(code, None).await?)
 }

--- a/crates/orchestrator/src/shared/types.rs
+++ b/crates/orchestrator/src/shared/types.rs
@@ -76,7 +76,6 @@ pub struct ParachainGenesisArgs {
     pub parachain: bool,
 }
 
-
 /// pjs-rs sucess call return type
 ///
 /// Represent the possible states returned from a succefully call to pjs-rs

--- a/crates/orchestrator/src/shared/types.rs
+++ b/crates/orchestrator/src/shared/types.rs
@@ -75,3 +75,16 @@ pub struct ParachainGenesisArgs {
     pub validation_code: String,
     pub parachain: bool,
 }
+
+
+/// pjs-rs sucess call return type
+///
+/// Represent the possible states returned from a succefully call to pjs-rs
+#[derive(Debug, Clone)]
+pub enum PjsSuccessResult {
+    /// Deserialized return value into a [serde_json::Value]
+    Value(serde_json::Value),
+    /// Execution of the script finish Ok, but the
+    /// returned value can not be deserialize into a [serde_json::Value]
+    DeserializeErrorMsg(String),
+}

--- a/crates/orchestrator/src/shared/types.rs
+++ b/crates/orchestrator/src/shared/types.rs
@@ -76,14 +76,11 @@ pub struct ParachainGenesisArgs {
     pub parachain: bool,
 }
 
-/// pjs-rs sucess call return type
+/// pjs-rs success [Result] type
 ///
 /// Represent the possible states returned from a succefully call to pjs-rs
-#[derive(Debug, Clone)]
-pub enum PjsSuccessResult {
-    /// Deserialized return value into a [serde_json::Value]
-    Value(serde_json::Value),
-    /// Execution of the script finish Ok, but the
-    /// returned value can not be deserialize into a [serde_json::Value]
-    DeserializeErrorMsg(String),
-}
+///
+/// Ok(value) -> Deserialized return value into a [serde_json::Value]
+/// Err(msg) -> Execution of the script finish Ok, but the returned value
+/// can't be deserialize into a [serde_json::Value]
+pub type PjsResult = Result<serde_json::Value, String>;

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 pub use configuration::{NetworkConfig, NetworkConfigBuilder, RegistrationStrategy};
 pub use orchestrator::{
-    errors::OrchestratorError, network::Network, AddCollatorOptions, AddNodeOptions, Orchestrator,
+    errors::OrchestratorError, network::Network, AddCollatorOptions, AddNodeOptions, Orchestrator, PjsSuccessResult,
 };
 use provider::NativeProvider;
 use support::{fs::local::LocalFileSystem, process::os::OsProcessManager};

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1,7 +1,8 @@
 use async_trait::async_trait;
 pub use configuration::{NetworkConfig, NetworkConfigBuilder, RegistrationStrategy};
 pub use orchestrator::{
-    errors::OrchestratorError, network::Network, AddCollatorOptions, AddNodeOptions, Orchestrator, PjsSuccessResult,
+    errors::OrchestratorError, network::Network, AddCollatorOptions, AddNodeOptions, Orchestrator,
+    PjsSuccessResult,
 };
 use provider::NativeProvider;
 use support::{fs::local::LocalFileSystem, process::os::OsProcessManager};

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 pub use configuration::{NetworkConfig, NetworkConfigBuilder, RegistrationStrategy};
 pub use orchestrator::{
     errors::OrchestratorError, network::Network, AddCollatorOptions, AddNodeOptions, Orchestrator,
-    PjsSuccessResult,
+    PjsResult,
 };
 use provider::NativeProvider;
 use support::{fs::local::LocalFileSystem, process::os::OsProcessManager};


### PR DESCRIPTION
- Add `pjs-rs` support and mimic the [javascript](https://polkadot.js.org/apps/#/js) tab from polkadot.js apps/
- Allow to use an external file or just an string with the `js/ts` code,

TODO: We should implement integration tests for this feature.


