### PR TITLE
feat: add parachains to a running network

### DIFF
--- a/crates/configuration/src/lib.rs
+++ b/crates/configuration/src/lib.rs
@@ -10,7 +10,9 @@ mod utils;
 pub use global_settings::{GlobalSettings, GlobalSettingsBuilder};
 pub use hrmp_channel::{HrmpChannelConfig, HrmpChannelConfigBuilder};
 pub use network::{NetworkConfig, NetworkConfigBuilder};
-pub use parachain::{ParachainConfig, ParachainConfigBuilder, RegistrationStrategy};
+pub use parachain::{
+    states as para_states, ParachainConfig, ParachainConfigBuilder, RegistrationStrategy,
+};
 pub use relaychain::{RelaychainConfig, RelaychainConfigBuilder};
 // re-export shared
 pub use shared::{node::NodeConfig, types};

--- a/crates/configuration/src/network.rs
+++ b/crates/configuration/src/network.rs
@@ -373,8 +373,11 @@ impl NetworkConfigBuilder<WithRelaychain> {
     pub fn with_parachain(
         self,
         f: fn(
-            ParachainConfigBuilder<parachain::Initial>,
-        ) -> ParachainConfigBuilder<parachain::WithAtLeastOneCollator>,
+            ParachainConfigBuilder<parachain::states::Initial, parachain::states::Bootstrap>,
+        ) -> ParachainConfigBuilder<
+            parachain::states::WithAtLeastOneCollator,
+            parachain::states::Bootstrap,
+        >,
     ) -> Self {
         match f(ParachainConfigBuilder::new(self.validation_context.clone())).build() {
             Ok(parachain) => Self::transition(

--- a/crates/configuration/src/shared/node.rs
+++ b/crates/configuration/src/shared/node.rs
@@ -18,6 +18,11 @@ use crate::{
     utils::{default_as_true, default_initial_balance},
 };
 
+states! {
+    Buildable,
+    Initial
+}
+
 /// An environment variable with a name and a value.
 /// It can be constructed from a `(&str, &str)`.
 ///
@@ -243,11 +248,6 @@ impl NodeConfig {
     pub fn db_snapshot(&self) -> Option<&AssetLocation> {
         self.db_snapshot.as_ref()
     }
-}
-
-states! {
-    Initial,
-    Buildable
 }
 
 /// A node configuration builder, used to build a [`NodeConfig`] declaratively with fields validation.

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -12,3 +12,4 @@ futures = { workspace = true }
 subxt = { workspace = true }
 tracing-subscriber = "0.3"
 serde_json = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/examples/examples/add_para.rs
+++ b/crates/examples/examples/add_para.rs
@@ -1,6 +1,6 @@
+use anyhow::anyhow;
 use futures::stream::StreamExt;
 use zombienet_sdk::{NetworkConfigBuilder, NetworkConfigExt};
-use anyhow::anyhow;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -12,11 +12,6 @@ async fn main() -> Result<(), anyhow::Error> {
                 .with_node(|node| node.with_name("alice"))
                 .with_node(|node| node.with_name("bob"))
         })
-        // .with_parachain(|p| {
-        //     p.with_id(100)
-        //         .cumulus_based(true)
-        //         .with_collator(|n| n.with_name("collator").with_command("polkadot-parachain"))
-        // })
         .build()
         .unwrap()
         .spawn_native()
@@ -36,16 +31,13 @@ async fn main() -> Result<(), anyhow::Error> {
 
     println!("⚙️  adding parachain to the running network");
 
-    let para_config = network.para_config_builder()
+    let para_config = network
+        .para_config_builder()
         .with_id(100)
         .with_default_command("polkadot-parachain")
-        .with_collator(|c| {
-            c.with_name("col-100-1")
-        })
+        .with_collator(|c| c.with_name("col-100-1"))
         .build()
-        .map_err(|_e| {
-            anyhow!("Building config")
-        })?;
+        .map_err(|_e| anyhow!("Building config"))?;
 
     network.add_parachain(&para_config, None).await?;
 

--- a/crates/examples/examples/add_para.rs
+++ b/crates/examples/examples/add_para.rs
@@ -1,0 +1,59 @@
+use futures::stream::StreamExt;
+use zombienet_sdk::{NetworkConfigBuilder, NetworkConfigExt};
+use anyhow::anyhow;
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    tracing_subscriber::fmt::init();
+    let mut network = NetworkConfigBuilder::new()
+        .with_relaychain(|r| {
+            r.with_chain("rococo-local")
+                .with_default_command("polkadot")
+                .with_node(|node| node.with_name("alice"))
+                .with_node(|node| node.with_name("bob"))
+        })
+        // .with_parachain(|p| {
+        //     p.with_id(100)
+        //         .cumulus_based(true)
+        //         .with_collator(|n| n.with_name("collator").with_command("polkadot-parachain"))
+        // })
+        .build()
+        .unwrap()
+        .spawn_native()
+        .await?;
+
+    println!("🚀🚀🚀🚀 network deployed");
+
+    let alice = network.get_node("alice")?;
+    let client = alice.client::<subxt::PolkadotConfig>().await?;
+
+    // wait 3 blocks
+    let mut blocks = client.blocks().subscribe_finalized().await?.take(3);
+
+    while let Some(block) = blocks.next().await {
+        println!("Block #{}", block?.header().number);
+    }
+
+    println!("⚙️  adding parachain to the running network");
+
+    let para_config = network.para_config_builder()
+        .with_id(100)
+        .with_default_command("polkadot-parachain")
+        .with_collator(|c| {
+            c.with_name("col-100-1")
+        })
+        .build()
+        .map_err(|_e| {
+            anyhow!("Building config")
+        })?;
+
+    network.add_parachain(&para_config, None).await?;
+
+    // For now let just loop....
+    #[allow(clippy::empty_loop)]
+    loop {}
+
+    #[allow(clippy::unreachable)]
+    #[allow(unreachable_code)]
+    Ok(())
+}

--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -497,6 +497,7 @@ impl ChainSpec {
         Ok(())
     }
 
+    /// Get the chain_is from the json content of a chain-spec file.
     pub fn chain_id_from_spec(spec_content: &str) -> Result<String, GeneratorError> {
         let chain_spec_json: serde_json::Value =
             serde_json::from_str(spec_content).map_err(|_| {

--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -213,22 +213,7 @@ impl ChainSpec {
         T: FileSystem,
     {
         let (content, _) = self.read_spec(scoped_fs).await?;
-        let chain_spec_json: serde_json::Value = serde_json::from_str(&content).map_err(|_| {
-            GeneratorError::ChainSpecGeneration("Can not parse chain-spec as json".into())
-        })?;
-        if let Some(chain_id) = chain_spec_json.get("id") {
-            if let Some(chain_id) = chain_id.as_str() {
-                Ok(chain_id.to_string())
-            } else {
-                Err(GeneratorError::ChainSpecGeneration(
-                    "id should be an string in the chain-spec, this is a bug".into(),
-                ))
-            }
-        } else {
-            Err(GeneratorError::ChainSpecGeneration(
-                "'id' should be a fields in the chain-spec of the relaychain".into(),
-            ))
-        }
+        ChainSpec::chain_id_from_spec(&content)
     }
 
     async fn read_spec<'a, T>(
@@ -510,6 +495,26 @@ impl ChainSpec {
         self.write_spec(scoped_fs, content).await?;
 
         Ok(())
+    }
+
+    pub fn chain_id_from_spec(spec_content: &str) -> Result<String, GeneratorError> {
+        let chain_spec_json: serde_json::Value =
+            serde_json::from_str(spec_content).map_err(|_| {
+                GeneratorError::ChainSpecGeneration("Can not parse chain-spec as json".into())
+            })?;
+        if let Some(chain_id) = chain_spec_json.get("id") {
+            if let Some(chain_id) = chain_id.as_str() {
+                Ok(chain_id.to_string())
+            } else {
+                Err(GeneratorError::ChainSpecGeneration(
+                    "id should be an string in the chain-spec, this is a bug".into(),
+                ))
+            }
+        } else {
+            Err(GeneratorError::ChainSpecGeneration(
+                "'id' should be a fields in the chain-spec of the relaychain".into(),
+            ))
+        }
     }
 }
 

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -98,33 +98,16 @@ where
         let relay_chain_name = network_spec.relaychain.chain.as_str();
         // TODO: if we don't need to register this para we can skip it
         for para in network_spec.parachains.iter_mut() {
-            let para_cloned = para.clone();
-            let chain_spec_raw_path = if let Some(chain_spec) = para.chain_spec.as_mut() {
-                chain_spec.build(&ns, &scoped_fs).await?;
-                debug!("chain_spec: {:#?}", chain_spec);
-
-                chain_spec
-                    .customize_para(&para_cloned, &relay_chain_id, &scoped_fs)
-                    .await?;
-                chain_spec.build_raw(&ns).await?;
-
-                let chain_spec_raw_path =
-                    chain_spec
-                        .raw_path()
-                        .ok_or(OrchestratorError::InvariantError(
-                            "chain-spec raw path should be set now",
-                        ))?;
-                Some(chain_spec_raw_path)
-            } else {
-                None
-            };
+            let chain_spec_raw_path = para
+                .build_chain_spec(&relay_chain_id, &ns, &scoped_fs)
+                .await?;
 
             // TODO: this need to be abstracted in a single call to generate_files.
             scoped_fs.create_dir(para.id.to_string()).await?;
             // create wasm/state
             para.genesis_state
                 .build(
-                    chain_spec_raw_path,
+                    chain_spec_raw_path.clone(),
                     format!("{}/genesis-state", para.id),
                     &ns,
                     &scoped_fs,
@@ -279,38 +262,11 @@ where
 
         // spawn paras
         for para in network_spec.parachains.iter() {
-            // global files to include for this parachain
-            let mut para_files_to_inject = global_files_to_inject.clone();
+            // Create parachain (in the context of the running network)
+            let parachain = Parachain::from_spec(para, &global_files_to_inject, &scoped_fs).await?;
+            let parachain_id = parachain.chain_id.clone();
 
-            // parachain id is used for the keystore
-            let parachain_id = if let Some(chain_spec) = para.chain_spec.as_ref() {
-                let id = chain_spec.read_chain_id(&scoped_fs).await?;
-
-                // add the spec to global files to inject
-                let spec_name = chain_spec.chain_spec_name();
-                para_files_to_inject.push(TransferedFile {
-                    local_path: ns.base_dir().join(format!("{}.json", spec_name)),
-                    remote_path: PathBuf::from(format!("/cfg/{}.json", para.id)),
-                });
-
-                let raw_path = chain_spec
-                    .raw_path()
-                    .ok_or(OrchestratorError::InvariantError(
-                        "chain-spec path should be set by now.",
-                    ))?;
-                let mut running_para = Parachain::with_chain_spec(para.id, &id, raw_path);
-                if let Some(chain_name) = chain_spec.chain_name() {
-                    running_para.chain = Some(chain_name.to_string());
-                }
-                network.add_para(running_para);
-
-                Some(id)
-            } else {
-                network.add_para(Parachain::new(para.id));
-
-                None
-            };
-
+            // Create `ctx` for spawn the nodes
             let ctx_para = SpawnNodeCtx {
                 parachain: Some(para),
                 parachain_id: parachain_id.as_deref(),
@@ -323,13 +279,16 @@ where
                 ..ctx.clone()
             };
 
-            let spawning_tasks = para
-                .collators
-                .iter()
-                .map(|node| spawner::spawn_node(node, para_files_to_inject.clone(), &ctx_para));
-            // TODO: Add para to Network instance
-            for node in futures::future::try_join_all(spawning_tasks).await? {
-                network.add_running_node(node, Some(para.id));
+            // Spawn the nodes
+            let spawning_tasks = para.collators.iter().map(|node| {
+                spawner::spawn_node(node, parachain.files_to_inject.clone(), &ctx_para)
+            });
+
+            let running_nodes = futures::future::try_join_all(spawning_tasks).await?;
+            let running_para_id = parachain.para_id;
+            network.add_para(parachain);
+            for node in running_nodes {
+                network.add_running_node(node, Some(running_para_id));
             }
         }
 

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -319,7 +319,7 @@ where
                     .to_path_buf(),
                 node_ws_url: node_ws_url.clone(),
                 onboard_as_para: para.onboard_as_parachain,
-                seed: None,          // TODO: Seed is passed by?
+                seed: None, // TODO: Seed is passed by?
                 finalization: false,
             };
 

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -320,7 +320,7 @@ where
                 node_ws_url: node_ws_url.clone(),
                 onboard_as_para: para.onboard_as_parachain,
                 seed: None,          // TODO: Seed is passed by?
-                finalization: false, // TODO: Seed is passed by?
+                finalization: false,
             };
 
             Parachain::register(register_para_options, &scoped_fs).await?;

--- a/crates/orchestrator/src/network.rs
+++ b/crates/orchestrator/src/network.rs
@@ -297,12 +297,43 @@ impl<T: FileSystem> Network<T> {
     }
 
     /// Get a parachain config builder from a running network
-    // TODO: build the validation context from the running network
+    ///
+    /// This allow you to build a new parachain config to be deployed into
+    /// the running network.
     pub fn para_config_builder(&self) -> ParachainConfigBuilder<Initial, Running> {
+        // TODO: build the validation context from the running network
         ParachainConfigBuilder::new_with_running(Default::default())
     }
 
-    // This should include at least of collator?
+    /// Add a new parachain to the running network
+    ///
+    /// NOTE: para_id must be unique in the whole network.
+    ///
+    /// # Example:
+    /// ```rust
+    /// # use anyhow::anyhow;
+    /// # use provider::NativeProvider;
+    /// # use support::{fs::local::LocalFileSystem, process::os::OsProcessManager};
+    /// # use zombienet_orchestrator::{errors, AddCollatorOptions, Orchestrator};
+    /// # use configuration::NetworkConfig;
+    /// # async fn example() -> Result<(), anyhow::Error> {
+    /// #   let provider = NativeProvider::new(LocalFileSystem {}, OsProcessManager {});
+    /// #   let orchestrator = Orchestrator::new(LocalFileSystem {}, provider);
+    /// #   let config = NetworkConfig::load_from_toml("config.toml")?;
+    /// let mut network = orchestrator.spawn(config).await?;
+    /// let para_config = network
+    ///     .para_config_builder()
+    ///     .with_id(100)
+    ///     .with_default_command("polkadot-parachain")
+    ///     .with_collator(|c| c.with_name("col-100-1"))
+    ///     .build()
+    ///     .map_err(|_e| anyhow!("Building config"))?;
+    ///
+    /// network.add_parachain(&para_config, None).await?;
+    ///
+    /// #   Ok(())
+    /// # }
+    /// ```
     pub async fn add_parachain(
         &mut self,
         para_config: &ParachainConfig,

--- a/crates/orchestrator/src/network.rs
+++ b/crates/orchestrator/src/network.rs
@@ -17,7 +17,10 @@ use self::{node::NetworkNode, parachain::Parachain, relaychain::Relaychain};
 use crate::{
     generators::chain_spec::ChainSpec,
     network_spec::{self, NetworkSpec},
-    shared::{macros, types::{ChainDefaultContext, RegisterParachainOptions}},
+    shared::{
+        macros,
+        types::{ChainDefaultContext, RegisterParachainOptions},
+    },
     spawner::{self, SpawnNodeCtx},
     ScopedFilesystem, ZombieRole,
 };
@@ -323,7 +326,11 @@ impl<T: FileSystem> Network<T> {
             ChainSpec::chain_id_from_spec(&content)?
         } else {
             global_files_to_inject.push(TransferedFile {
-                local_path: PathBuf::from(format!("{}/{}",scoped_fs.base_dir,self.relaychain().chain_spec_path.to_string_lossy())),
+                local_path: PathBuf::from(format!(
+                    "{}/{}",
+                    scoped_fs.base_dir,
+                    self.relaychain().chain_spec_path.to_string_lossy()
+                )),
                 remote_path: PathBuf::from(format!("/cfg/{}.json", self.relaychain().chain)),
             });
             self.relay.chain_id.clone()
@@ -375,7 +382,14 @@ impl<T: FileSystem> Network<T> {
         };
 
         // Register the parachain to the running network
-        let first_node_url = self.relaychain().nodes.first().ok_or(anyhow::anyhow!("At least one node of the relaychain should be running"))?.ws_uri();
+        let first_node_url = self
+            .relaychain()
+            .nodes
+            .first()
+            .ok_or(anyhow::anyhow!(
+                "At least one node of the relaychain should be running"
+            ))?
+            .ws_uri();
         let register_para_options = RegisterParachainOptions {
             id: parachain.para_id,
             // This needs to resolve correctly
@@ -395,7 +409,7 @@ impl<T: FileSystem> Network<T> {
                 .to_path_buf(),
             node_ws_url: first_node_url.to_string(),
             onboard_as_para: para_spec.onboard_as_parachain,
-            seed: None,          // TODO: Seed is passed by?
+            seed: None, // TODO: Seed is passed by?
             finalization: false,
         };
 

--- a/crates/orchestrator/src/network/parachain.rs
+++ b/crates/orchestrator/src/network/parachain.rs
@@ -62,7 +62,6 @@ impl Parachain {
         let mut para_files_to_inject = files_to_inject.to_owned();
 
         // parachain id is used for the keystore
-        // let parachain_id = if let Some(chain_spec) = para.chain_spec.as_ref() {
         let mut para = if let Some(chain_spec) = para.chain_spec.as_ref() {
             let id = chain_spec.read_chain_id(scoped_fs).await?;
 

--- a/crates/orchestrator/src/network_spec/parachain.rs
+++ b/crates/orchestrator/src/network_spec/parachain.rs
@@ -189,6 +189,10 @@ impl ParachainSpec {
         Ok(para_spec)
     }
 
+    /// Build parachain chain-spec
+    ///
+    /// This fn customize the chain-spec (if is possible) and build the raw version
+    /// of the chain-spec.
     pub(crate) async fn build_chain_spec<'a, T>(
         &mut self,
         relay_chain_id: &str,


### PR DESCRIPTION
This pr make possible to add a new parachain to a running network (see `add_para.rs` example), for that we allow to create a new parachain config (using the same builder but in a different context) like this:

```rs
let para_config = network.para_config_builder()
        .with_id(100)
        .with_default_command("polkadot-parachain")
        .with_collator(|c| {
            c.with_name("col-100-1")
        })
        .build()?;
```
And then deploy that parachain by calling `add_parachain` (the second parameter of the fn allow to use a custom chain-spec for the relaychain).

```rs
network.add_parachain(&para_config, None).await?;
```

// TODO:
- [x] docs
- [ ] test (integration)