### PR TITLE
fileserver: add default route to use as health check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          # TODO 24-02-06: this is pinned due to tkaitchuck/aHash#200.
-          - nightly-2024-02-01
+          # TODO 24-02-08: Disable nightly due to tkaitchuck/aHash#200.
           #- nightly
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - nightly
+          # TODO 24-02-06: this is pinned due to tkaitchuck/aHash#200.
+          - nightly-2024-02-01
+          #- nightly
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,9 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - nightly
+          # TODO 24-02-08: Disable nightly due to tkaitchuck/aHash#200.
+          #- nightly
+          - stable
     steps:
       - uses: actions/checkout@v3
 

--- a/crates/file-server/src/main.rs
+++ b/crates/file-server/src/main.rs
@@ -48,7 +48,6 @@ async fn main() {
     axum::serve(listener, app).await.unwrap()
 }
 
-
 async fn upload(
     Path(file_path): Path<String>,
     State(state): State<AppState>,

--- a/crates/file-server/src/main.rs
+++ b/crates/file-server/src/main.rs
@@ -4,7 +4,7 @@ use std::io;
 use axum::{
     extract::{Path, Request, State},
     http::StatusCode,
-    routing::post,
+    routing::{get, post},
     Router,
 };
 use futures::TryStreamExt;
@@ -34,6 +34,7 @@ async fn main() {
         .expect(&format!("failed to create '{uploads_directory}' directory"));
 
     let app = Router::new()
+        .route("/", get(|| async { "Ok" }))
         .route(
             "/*file_path",
             post(upload).get_service(ServeDir::new(&uploads_directory)),
@@ -46,6 +47,7 @@ async fn main() {
     tracing::info!("file server started on {}", listener.local_addr().unwrap());
     axum::serve(listener, app).await.unwrap()
 }
+
 
 async fn upload(
     Path(file_path): Path<String>,


### PR DESCRIPTION
We want to add an `startupProbe` setting to the fileserver pod.
