### PR TITLE
fix: enable arbitrary_precision for serde_json

### DIFF
--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["zombienet", "orchestrator", "sdk"]
 tokio = { workspace = true, features = ["time"] }
 thiserror = { workspace = true }
 multiaddr = { workspace = true }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["arbitrary_precision"] }
 futures = { workspace = true }
 anyhow = { workspace = true }
 rand = { workspace = true }


### PR DESCRIPTION
Testing with moonbeam and found that the resulting chainspec produced using the `moonbase-local` chain develops the following issue after the generated plain chainspec is updated with the relevant para id:

```
Error: Zombienet(SpawnerError(Provider error
Caused by:
    File generation failed: Error: Service(Other("Error parsing spec file: trailing characters at line 25 column 14"))
```

The initial chainspec built from the binary is fine, but once https://github.com/paritytech/zombienet-sdk/blob/e60deb254b5f58e81a55300ae802d5b614f774e5/crates/orchestrator/src/generators/chain_spec.rs#L345-L349 runs the issue occurs, as seen in the the following diff:

```
--- moonbase-local-plain copy.json	2024-02-11 02:51:15
+++ moonbase-local-plain.json	2024-02-11 02:52:24
@@ -11,7 +11,7 @@
     "tokenSymbol": "UNIT"
   },
   "relayChain": "westend-local",
-  "paraId": 1000,
+  "paraId": 2000,
   "codeSubstitutes": {},
   "genesis": {
     "runtime": {
\ No newline at end of file
@@ -22,19 +22,19 @@
         "balances": [
           [
             "0xf24ff3a9cf04c71dbc94d0b566f7a27b94566cac",
-            1208925819614629174706176
+            1.2089258196146292e24
           ],
           [
             "0x3cd0a705a2dc65e5b1e1205896baa2be8a07c6e0",
-            1208925819614629174706176
+            1.2089258196146292e24
           ],
           [
             "0x798d4ba9baf0064ec19eb4f0a1a45785ae9d6dfc",
-            1208925819614629174706176
+            1.2089258196146292e24
           ],
           [
             "0x773539d4ac0e786233d90a233654ccee26a613d9",
-            1208925819614629174706176
+            1.2089258196146292e24
           ]
         ]
       },
\ No newline at end of file
@@ -45,7 +45,7 @@
         "multiplier": "8000000000000000000"
       },
       "parachainInfo": {
-        "parachainId": 1000
+        "parachainId": 2000
       },
       "ethereumChainId": {
         "chainId": 1280
\ No newline at end of file
@@ -503,19 +503,19 @@
         "candidates": [
           [
             "0xf24ff3a9cf04c71dbc94d0b566f7a27b94566cac",
-            1000000000000000000000
+            1e21
           ],
           [
             "0x3cd0a705a2dc65e5b1e1205896baa2be8a07c6e0",
-            1000000000000000000000
+            1e21
           ]
         ],
         "delegations": [],
         "inflationConfig": {
           "expect": {
-            "min": 100000000000000000000000,
-            "ideal": 200000000000000000000000,
-            "max": 500000000000000000000000
+            "min": 1e23,
+            "ideal": 2e23,
+            "max": 5e23
           },
           "annual": {
             "min": 40000000,
\ No newline at end of file
@@ -552,7 +552,7 @@
         "eligibleCount": 50
       },
       "crowdloanRewards": {
-        "fundedAmount": 3000000000000000000000000
+        "fundedAmount": 3e24
       },
       "authorMapping": {
         "mappings": [
\ No newline at end of file
@@ -611,6 +611,11 @@
           "0xf24ff3a9cf04c71dbc94d0b566f7a27b94566cac",
           "0x3cd0a705a2dc65e5b1e1205896baa2be8a07c6e0"
         ]
+      },
+      "aura": {
+        "authorities": [
+          "5HEL3iLyDyaqmfibHXAXVzyQq4fBqLCHGMEYxZXgRAuhEKXX"
+        ]
       }
     }
   }
```

The fix appears to be to enable the [`arbitrary_precision`](https://github.com/serde-rs/json/blob/master/Cargo.toml#L75) feature on `serde_json`, which can be seen at https://github.com/paritytech/polkadot-sdk/pull/2987/files. Manually tested and solves the issue for me.