### PR TITLE
Fixes for native provider and allow manual para registration

### DIFF
--- a/crates/configuration/src/parachain.rs
+++ b/crates/configuration/src/parachain.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, error::Error, fmt::Display, marker::PhantomData, rc::Rc};
-use anyhow::anyhow;
 
+use anyhow::anyhow;
 use multiaddr::Multiaddr;
 use serde::{
     de::{self, Visitor},
@@ -25,7 +25,7 @@ use crate::{
 pub enum RegistrationStrategy {
     InGenesis,
     UsingExtrinsic,
-    Manual
+    Manual,
 }
 
 impl Serialize for RegistrationStrategy {
@@ -41,8 +41,7 @@ impl Serialize for RegistrationStrategy {
             Self::Manual => {
                 state.serialize_field("add_to_genesis", &false)?;
                 state.serialize_field("register_para", &false)?;
-
-            }
+            },
         }
 
         state.end()
@@ -348,13 +347,17 @@ impl ParachainConfigBuilder<WithId, Running> {
     ///  using an extrinsic. Genesis option is not allowed in `Running` context.
     pub fn with_registration_strategy(self, strategy: RegistrationStrategy) -> Self {
         match strategy {
-            RegistrationStrategy::InGenesis => {
-                Self::transition(
-                    self.config,
-                    self.validation_context,
-                    merge_errors(self.errors, FieldError::RegistrationStrategy(anyhow!("Can be set to InGenesis in Running context")).into())
-                )
-            },
+            RegistrationStrategy::InGenesis => Self::transition(
+                self.config,
+                self.validation_context,
+                merge_errors(
+                    self.errors,
+                    FieldError::RegistrationStrategy(anyhow!(
+                        "Can be set to InGenesis in Running context"
+                    ))
+                    .into(),
+                ),
+            ),
             RegistrationStrategy::Manual | RegistrationStrategy::UsingExtrinsic => {
                 Self::transition(
                     ParachainConfig {

--- a/crates/configuration/src/parachain.rs
+++ b/crates/configuration/src/parachain.rs
@@ -1,4 +1,5 @@
 use std::{cell::RefCell, error::Error, fmt::Display, marker::PhantomData, rc::Rc};
+use anyhow::anyhow;
 
 use multiaddr::Multiaddr;
 use serde::{
@@ -24,6 +25,7 @@ use crate::{
 pub enum RegistrationStrategy {
     InGenesis,
     UsingExtrinsic,
+    Manual
 }
 
 impl Serialize for RegistrationStrategy {
@@ -36,6 +38,11 @@ impl Serialize for RegistrationStrategy {
         match self {
             Self::InGenesis => state.serialize_field("add_to_genesis", &true)?,
             Self::UsingExtrinsic => state.serialize_field("register_para", &true)?,
+            Self::Manual => {
+                state.serialize_field("add_to_genesis", &false)?;
+                state.serialize_field("register_para", &false)?;
+
+            }
         }
 
         state.end()
@@ -322,7 +329,8 @@ impl ParachainConfigBuilder<Initial, Bootstrap> {
 }
 
 impl ParachainConfigBuilder<WithId, Bootstrap> {
-    /// Set the registration strategy for the parachain, could be without registration, using extrinsic or in genesis.
+    /// Set the registration strategy for the parachain, could be Manual (no registered by zombienet) or automatic
+    ///  using an extrinsic or in genesis.
     pub fn with_registration_strategy(self, strategy: RegistrationStrategy) -> Self {
         Self::transition(
             ParachainConfig {
@@ -332,6 +340,32 @@ impl ParachainConfigBuilder<WithId, Bootstrap> {
             self.validation_context,
             self.errors,
         )
+    }
+}
+
+impl ParachainConfigBuilder<WithId, Running> {
+    /// Set the registration strategy for the parachain, could be Manual (no registered by zombienet) or automatic
+    ///  using an extrinsic. Genesis option is not allowed in `Running` context.
+    pub fn with_registration_strategy(self, strategy: RegistrationStrategy) -> Self {
+        match strategy {
+            RegistrationStrategy::InGenesis => {
+                Self::transition(
+                    self.config,
+                    self.validation_context,
+                    merge_errors(self.errors, FieldError::RegistrationStrategy(anyhow!("Can be set to InGenesis in Running context")).into())
+                )
+            },
+            RegistrationStrategy::Manual | RegistrationStrategy::UsingExtrinsic => {
+                Self::transition(
+                    ParachainConfig {
+                        registration_strategy: Some(strategy),
+                        ..self.config
+                    },
+                    self.validation_context,
+                    self.errors,
+                )
+            },
+        }
     }
 }
 

--- a/crates/configuration/src/shared/errors.rs
+++ b/crates/configuration/src/shared/errors.rs
@@ -81,6 +81,10 @@ pub enum FieldError {
 
     #[error("p2p_port: {0}")]
     P2pPort(anyhow::Error),
+
+    #[error("registration_strategy: {0}")]
+    RegistrationStrategy(anyhow::Error),
+
 }
 
 /// A conversion error for shared types across fields.

--- a/crates/configuration/src/shared/errors.rs
+++ b/crates/configuration/src/shared/errors.rs
@@ -84,7 +84,6 @@ pub enum FieldError {
 
     #[error("registration_strategy: {0}")]
     RegistrationStrategy(anyhow::Error),
-
 }
 
 /// A conversion error for shared types across fields.

--- a/crates/orchestrator/src/generators/command.rs
+++ b/crates/orchestrator/src/generators/command.rs
@@ -232,7 +232,7 @@ pub fn generate_for_node(
 
     if *is_validator && !args.contains(&Arg::Flag("--validator".into())) {
         tmp_args.push("--validator".into());
-        // tmp_args.push("--insecure-validator-i-know-what-i-do".into());
+        tmp_args.push("--insecure-validator-i-know-what-i-do".into());
     }
 
     if !bootnodes_addresses.is_empty() {

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -131,8 +131,10 @@ where
         let (para_to_register_in_genesis, para_to_register_with_extrinsic): (
             Vec<&ParachainSpec>,
             Vec<&ParachainSpec>,
-        ) = network_spec.parachains.iter().partition(|para| {
-            matches!(para.registration_strategy, RegistrationStrategy::InGenesis)
+        ) = network_spec.parachains.iter()
+            .filter(|para| para.registration_strategy != RegistrationStrategy::Manual)
+            .partition(|para| {
+                matches!(para.registration_strategy, RegistrationStrategy::InGenesis)
         });
 
         let mut para_artifacts = vec![];

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -131,11 +131,13 @@ where
         let (para_to_register_in_genesis, para_to_register_with_extrinsic): (
             Vec<&ParachainSpec>,
             Vec<&ParachainSpec>,
-        ) = network_spec.parachains.iter()
+        ) = network_spec
+            .parachains
+            .iter()
             .filter(|para| para.registration_strategy != RegistrationStrategy::Manual)
             .partition(|para| {
                 matches!(para.registration_strategy, RegistrationStrategy::InGenesis)
-        });
+            });
 
         let mut para_artifacts = vec![];
         for para in para_to_register_in_genesis {

--- a/crates/orchestrator/src/spawner.rs
+++ b/crates/orchestrator/src/spawner.rs
@@ -105,9 +105,9 @@ where
             NODE_RELAY_DATA_DIR.into(),
         )
     } else {
-        let cfg_path = format!("{}/{NODE_CONFIG_DIR}", &base_dir);
-        let data_path = format!("{}/{NODE_DATA_DIR}", &base_dir);
-        let relay_data_path = format!("{}/{NODE_RELAY_DATA_DIR}", &base_dir);
+        let cfg_path = format!("{}{NODE_CONFIG_DIR}", &base_dir);
+        let data_path = format!("{}{NODE_DATA_DIR}", &base_dir);
+        let relay_data_path = format!("{}{NODE_RELAY_DATA_DIR}", &base_dir);
         (cfg_path, data_path, relay_data_path)
     };
 
@@ -165,6 +165,7 @@ where
     };
 
     // Drops the port parking listeners before spawn
+    node.ws_port.drop_listener();
     node.p2p_port.drop_listener();
     node.rpc_port.drop_listener();
     node.prometheus_port.drop_listener();
@@ -183,13 +184,13 @@ where
     // Create port-forward iff we are not in CI
     if !running_in_ci() {
         let ports = futures::future::try_join_all(vec![
-            running_node.create_port_forward(node.ws_port.0, RPC_PORT),
+            running_node.create_port_forward(node.rpc_port.0, RPC_PORT),
             running_node.create_port_forward(node.prometheus_port.0, PROMETHEUS_PORT),
         ])
         .await?;
 
         (rpc_port_external, prometheus_port_external) = (
-            ports[0].unwrap_or(node.ws_port.0),
+            ports[0].unwrap_or(node.rpc_port.0),
             ports[1].unwrap_or(node.prometheus_port.0),
         );
     } else {

--- a/crates/provider/src/native/namespace.rs
+++ b/crates/provider/src/native/namespace.rs
@@ -99,6 +99,7 @@ where
             &options.args,
             &options.env,
             &options.injected_files,
+            &options.created_paths,
             &self.filesystem,
         )
         .await?;

--- a/crates/provider/src/native/node.rs
+++ b/crates/provider/src/native/node.rs
@@ -121,20 +121,13 @@ where
         Ok(node)
     }
 
-    async fn initialize_startup_paths(
-        &self,
-        paths: &[PathBuf]
-    ) -> Result<(), ProviderError> {
+    async fn initialize_startup_paths(&self, paths: &[PathBuf]) -> Result<(), ProviderError> {
         trace!("creating paths {:?}", paths);
         let base_dir_raw = self.base_dir.to_string_lossy();
-        try_join_all(
-            paths
-                .iter()
-                .map(|file| {
-                    let full_path = format!("{base_dir_raw}{}", file.to_string_lossy());
-                    self.filesystem.create_dir_all(full_path)
-                })
-        )
+        try_join_all(paths.iter().map(|file| {
+            let full_path = format!("{base_dir_raw}{}", file.to_string_lossy());
+            self.filesystem.create_dir_all(full_path)
+        }))
         .await?;
         trace!("paths created!");
 


### PR DESCRIPTION
Add: Manual variant to `RegistrationStrategy`, allow to deploy the collators _but_ not register the para.
Fix: `created_paths` in native provider
Fix: Use `rpc` port for ws connections (orchestrator)