### PR TITLE
feat: Allow add para to running network without register

### DIFF
--- a/crates/configuration/src/network.rs
+++ b/crates/configuration/src/network.rs
@@ -427,8 +427,6 @@ impl NetworkConfigBuilder<WithRelaychain> {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
-
     use super::*;
     use crate::parachain::RegistrationStrategy;
 

--- a/crates/provider/src/kubernetes/namespace.rs
+++ b/crates/provider/src/kubernetes/namespace.rs
@@ -60,7 +60,7 @@ where
         filesystem: &FS,
     ) -> Result<Arc<Self>, ProviderError> {
         let name = format!("{}{}", NAMESPACE_PREFIX, Uuid::new_v4());
-        let base_dir = PathBuf::from_iter([&tmp_dir, &PathBuf::from(&name)]);
+        let base_dir = PathBuf::from_iter([tmp_dir, &PathBuf::from(&name)]);
         filesystem.create_dir(&base_dir).await?;
 
         let namespace = Arc::new_cyclic(|weak| KubernetesNamespace {

--- a/crates/provider/src/kubernetes/node.rs
+++ b/crates/provider/src/kubernetes/node.rs
@@ -73,7 +73,7 @@ where
         let filesystem = options.filesystem.clone();
 
         let base_dir =
-            PathBuf::from_iter([&options.namespace_base_dir, &PathBuf::from(options.name)]);
+            PathBuf::from_iter([(options.namespace_base_dir), &PathBuf::from(options.name)]);
         filesystem.create_dir_all(&base_dir).await?;
 
         let base_dir_raw = base_dir.to_string_lossy();

--- a/crates/provider/src/native/namespace.rs
+++ b/crates/provider/src/native/namespace.rs
@@ -45,7 +45,7 @@ where
         filesystem: &FS,
     ) -> Result<Arc<Self>, ProviderError> {
         let name = format!("{}{}", NAMESPACE_PREFIX, Uuid::new_v4());
-        let base_dir = PathBuf::from_iter([&tmp_dir, &PathBuf::from(&name)]);
+        let base_dir = PathBuf::from_iter([tmp_dir, &PathBuf::from(&name)]);
         filesystem.create_dir(&base_dir).await?;
 
         Ok(Arc::new_cyclic(|weak| NativeNamespace {

--- a/crates/provider/src/native/node.rs
+++ b/crates/provider/src/native/node.rs
@@ -71,7 +71,7 @@ where
         created_paths: &[PathBuf],
         filesystem: &FS,
     ) -> Result<Arc<Self>, ProviderError> {
-        let base_dir = PathBuf::from_iter([&namespace_base_dir, &PathBuf::from(name)]);
+        let base_dir = PathBuf::from_iter([namespace_base_dir, &PathBuf::from(name)]);
         trace!("creating base_dir {:?}", base_dir);
         filesystem.create_dir_all(&base_dir).await?;
         trace!("created base_dir {:?}", base_dir);

--- a/crates/provider/src/shared/helpers.rs
+++ b/crates/provider/src/shared/helpers.rs
@@ -30,8 +30,6 @@ pub fn running_in_ci() -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use super::*;
 
     #[test]


### PR DESCRIPTION
- Add `custom_parchain_fs_prefix` parameter to `add_para` fn (on running network), this allow to manage the fs layout and allow to add paras with the same id. 
- Minor clippy auto-fixes

cc: @metricaez 