### PR TITLE
Fix builder pattern to allow real closures

### DIFF
--- a/crates/configuration/src/network.rs
+++ b/crates/configuration/src/network.rs
@@ -324,7 +324,7 @@ impl NetworkConfigBuilder<Initial> {
     /// Set the relay chain using a nested [`RelaychainConfigBuilder`].
     pub fn with_relaychain(
         self,
-        f: fn(
+        f: impl FnOnce(
             RelaychainConfigBuilder<relaychain::Initial>,
         ) -> RelaychainConfigBuilder<relaychain::WithAtLeastOneNode>,
     ) -> NetworkConfigBuilder<WithRelaychain> {
@@ -350,7 +350,7 @@ impl NetworkConfigBuilder<WithRelaychain> {
     /// Set the global settings using a nested [`GlobalSettingsBuilder`].
     pub fn with_global_settings(
         self,
-        f: fn(GlobalSettingsBuilder) -> GlobalSettingsBuilder,
+        f: impl FnOnce(GlobalSettingsBuilder) -> GlobalSettingsBuilder,
     ) -> Self {
         match f(GlobalSettingsBuilder::new()).build() {
             Ok(global_settings) => Self::transition(
@@ -372,7 +372,7 @@ impl NetworkConfigBuilder<WithRelaychain> {
     /// Add a parachain using a nested [`ParachainConfigBuilder`].
     pub fn with_parachain(
         self,
-        f: fn(
+        f: impl FnOnce(
             ParachainConfigBuilder<parachain::states::Initial, parachain::states::Bootstrap>,
         ) -> ParachainConfigBuilder<
             parachain::states::WithAtLeastOneCollator,
@@ -399,7 +399,7 @@ impl NetworkConfigBuilder<WithRelaychain> {
     /// Add an HRMP channel using a nested [`HrmpChannelConfigBuilder`].
     pub fn with_hrmp_channel(
         self,
-        f: fn(
+        f: impl FnOnce(
             HrmpChannelConfigBuilder<hrmp_channel::Initial>,
         ) -> HrmpChannelConfigBuilder<hrmp_channel::WithRecipient>,
     ) -> Self {


### PR DESCRIPTION
Sticking to the `fn` type in the builder pattern doesn't make much sense to me. Consider the following snippet:

```rust
    let overrides = json!({ "runtimeGenesis": { "patch": { "configuration": { "config": { "max_pov_size": 5_242_880 } } } } });
    let config = NetworkConfigBuilder::new()
        .with_relaychain(|r| {
            r.with_chain("rococo-local")
                .with_genesis_overrides(overrides)
                .with_node(|node| node.with_name("alice").with_command("polkadot"))
        })
        .build();
```

That wouldn't compile, as the `.with_relaychain()` argument closure captures the `overrides` variable and thus cannot be coerced to `fn` anymore. That is, `.with_genesis_overrides` becomes useless unless you want to pass a simple literal there.

On the other hand, all those closures are single-shot, allowing us to make them `FnOnce,` which is relatively relaxed. If `.with_relaychain()` accepts `impl FnOnce` instead of `fn`, the example above compiles successfully.