### PR TITLE
fix(orchestrator): use pointer from 'get_runtime_config_pointer'

### DIFF
--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -343,8 +343,7 @@ impl ChainSpec {
 
             // make genesis overrides first.
             if let Some(overrides) = &para.genesis_overrides {
-                if let Some(genesis) = chain_spec_json.pointer_mut(&format!("{}/genesis", pointer))
-                {
+                if let Some(genesis) = chain_spec_json.pointer_mut(&pointer) {
                     merge(genesis, overrides);
                 }
             }


### PR DESCRIPTION
Fix #173 

We should also add a follow up issue to improve the docs.

cc: @s0me0ne-unkn0wn 