### PR TITLE
Validate spec for provider

### DIFF
--- a/crates/configuration/src/parachain.rs
+++ b/crates/configuration/src/parachain.rs
@@ -687,7 +687,7 @@ impl<C: Context> ParachainConfigBuilder<WithId, C> {
     /// Add a new collator using a nested [`NodeConfigBuilder`].
     pub fn with_collator(
         self,
-        f: fn(NodeConfigBuilder<node::Initial>) -> NodeConfigBuilder<node::Buildable>,
+        f: impl FnOnce(NodeConfigBuilder<node::Initial>) -> NodeConfigBuilder<node::Buildable>,
     ) -> ParachainConfigBuilder<WithAtLeastOneCollator, C> {
         match f(NodeConfigBuilder::new(
             self.default_chain_context(),

--- a/crates/orchestrator/src/errors.rs
+++ b/crates/orchestrator/src/errors.rs
@@ -10,6 +10,8 @@ pub enum OrchestratorError {
     // TODO: improve invalid config reporting
     #[error("Invalid network configuration: {0}")]
     InvalidConfig(String),
+    #[error("Invalid network config to use provider {0}: {1}")]
+    InvalidConfigForProvider(String, String),
     #[error("Invalid configuration for node: {0}, field: {1}")]
     InvalidNodeConfig(String, String),
     #[error("Invariant not fulfilled {0}")]

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -385,7 +385,7 @@ fn validate_spec_with_provider_capabilities(
         }
     };
 
-    // paras
+    // Paras
     for para in &network_spec.parachains {
         if para.default_image.is_none() {
             let nodes = &para.collators;

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -495,8 +495,6 @@ mod tests {
     use super::*;
 
     fn generate(with_image: bool) -> Result<NetworkConfig, Vec<anyhow::Error>> {
-
-
         NetworkConfigBuilder::new()
             .with_relaychain(|r| {
                 let mut relay = r

--- a/crates/provider/src/kubernetes/provider.rs
+++ b/crates/provider/src/kubernetes/provider.rs
@@ -13,6 +13,8 @@ use crate::{
     types::ProviderCapabilities, DynNamespace, Provider, ProviderError, ProviderNamespace,
 };
 
+const PROVIDER_NAME: &str = "k8s";
+
 pub struct KubernetesProvider<FS>
 where
     FS: FileSystem + Send + Sync + Clone,
@@ -58,6 +60,10 @@ impl<FS> Provider for KubernetesProvider<FS>
 where
     FS: FileSystem + Send + Sync + Clone + 'static,
 {
+    fn name(&self) -> &str {
+        PROVIDER_NAME
+    }
+
     fn capabilities(&self) -> &ProviderCapabilities {
         &self.capabilities
     }

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -104,6 +104,8 @@ pub enum ProviderError {
 
 #[async_trait]
 pub trait Provider {
+    fn name(&self) -> &str;
+
     fn capabilities(&self) -> &ProviderCapabilities;
 
     async fn namespaces(&self) -> HashMap<String, DynNamespace>;

--- a/crates/provider/src/native/provider.rs
+++ b/crates/provider/src/native/provider.rs
@@ -13,6 +13,8 @@ use crate::{
     types::ProviderCapabilities, DynNamespace, Provider, ProviderError, ProviderNamespace,
 };
 
+const PROVIDER_NAME: &str = "native";
+
 pub struct NativeProvider<FS>
 where
     FS: FileSystem + Send + Sync + Clone,
@@ -58,6 +60,10 @@ impl<FS> Provider for NativeProvider<FS>
 where
     FS: FileSystem + Send + Sync + Clone + 'static,
 {
+    fn name(&self) -> &str {
+        PROVIDER_NAME
+    }
+
     fn capabilities(&self) -> &ProviderCapabilities {
         &self.capabilities
     }


### PR DESCRIPTION
Add small validation, mostly to ensure that the `image` is set in k8s.

fix #143 
