### PR TITLE
Feat: impl db snap logic for k8s/native

### DIFF
--- a/crates/examples/examples/db_snapshot.rs
+++ b/crates/examples/examples/db_snapshot.rs
@@ -1,0 +1,29 @@
+use zombienet_sdk::{NetworkConfigBuilder, NetworkConfigExt};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+    let mut _network = NetworkConfigBuilder::new()
+        .with_relaychain(|r| {
+            r.with_chain("rococo-local")
+                .with_default_command("substrate")
+                .with_default_image("docker.io/paritypr/substrate:3428-e5be9c93")
+                .with_default_db_snapshot("https://storage.googleapis.com/zombienet-db-snaps/substrate/0001-basic-warp-sync/chains-9677807d738b951e9f6c82e5fd15518eb0ae0419.tgz")
+                .with_chain_spec_path("/Users/pepo/parity/polkadot-sdk/substrate/zombienet/0001-basic-warp-sync/chain-spec.json")
+                .with_node(|node| node.with_name("alice"))
+                .with_node(|node| node.with_name("bob"))
+                .with_node(|node| node.with_name("charlie"))
+        })
+        .build()
+        .unwrap()
+        // .spawn_native()
+        .spawn_k8s()
+        .await?;
+
+    println!("🚀🚀🚀🚀 network deployed");
+
+    // For now let just loop....
+    #[allow(clippy::empty_loop)]
+    loop {}
+
+}

--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -162,7 +162,18 @@ impl ChainSpec {
         }
 
         if is_raw(maybe_plain_spec_path.clone(), scoped_fs).await? {
-            self.raw_path = Some(maybe_plain_spec_path);
+            let spec_path = PathBuf::from(format!("{}.json", self.chain_spec_name));
+            let tf_file = TransferedFile::new(&PathBuf::from_iter([ns.base_dir(), &maybe_plain_spec_path]), &spec_path);
+            scoped_fs
+            .copy_files(vec![&tf_file])
+            .await
+            .map_err(|e| {
+                GeneratorError::ChainSpecGeneration(format!(
+                    "Error copying file: {}, err: {}", tf_file, e
+                ))
+            })?;
+
+            self.raw_path = Some(spec_path);
         } else {
             self.maybe_plain_path = Some(maybe_plain_spec_path);
         }

--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -163,13 +163,14 @@ impl ChainSpec {
 
         if is_raw(maybe_plain_spec_path.clone(), scoped_fs).await? {
             let spec_path = PathBuf::from(format!("{}.json", self.chain_spec_name));
-            let tf_file = TransferedFile::new(&PathBuf::from_iter([ns.base_dir(), &maybe_plain_spec_path]), &spec_path);
-            scoped_fs
-            .copy_files(vec![&tf_file])
-            .await
-            .map_err(|e| {
+            let tf_file = TransferedFile::new(
+                &PathBuf::from_iter([ns.base_dir(), &maybe_plain_spec_path]),
+                &spec_path,
+            );
+            scoped_fs.copy_files(vec![&tf_file]).await.map_err(|e| {
                 GeneratorError::ChainSpecGeneration(format!(
-                    "Error copying file: {}, err: {}", tf_file, e
+                    "Error copying file: {}, err: {}",
+                    tf_file, e
                 ))
             })?;
 

--- a/crates/orchestrator/src/generators/command.rs
+++ b/crates/orchestrator/src/generators/command.rs
@@ -232,7 +232,8 @@ pub fn generate_for_node(
 
     if *is_validator && !args.contains(&Arg::Flag("--validator".into())) {
         tmp_args.push("--validator".into());
-        // tmp_args.push("--insecure-validator-i-know-what-i-do".into());
+        // TODO: we need to impl cli args checking
+        tmp_args.push("--insecure-validator-i-know-what-i-do".into());
     }
 
     if !bootnodes_addresses.is_empty() {

--- a/crates/orchestrator/src/generators/command.rs
+++ b/crates/orchestrator/src/generators/command.rs
@@ -232,7 +232,7 @@ pub fn generate_for_node(
 
     if *is_validator && !args.contains(&Arg::Flag("--validator".into())) {
         tmp_args.push("--validator".into());
-        tmp_args.push("--insecure-validator-i-know-what-i-do".into());
+        // tmp_args.push("--insecure-validator-i-know-what-i-do".into());
     }
 
     if !bootnodes_addresses.is_empty() {

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -21,7 +21,7 @@ use network_spec::{parachain::ParachainSpec, NetworkSpec};
 use provider::{types::TransferedFile, DynProvider};
 use support::fs::{FileSystem, FileSystemError};
 use tokio::time::timeout;
-use tracing::{debug, info};
+use tracing::{debug, info, trace};
 
 use crate::{
     generators::chain_spec::ParaGenesisConfig,
@@ -382,6 +382,7 @@ impl<'a, FS: FileSystem> ScopedFilesystem<'a, FS> {
                 self.base_dir,
                 file.remote_path.to_string_lossy()
             ));
+            trace!("coping file: {file}");
             self.fs
                 .copy(file.local_path.as_path(), full_remote_path)
                 .await?;

--- a/crates/orchestrator/src/network_spec/node.rs
+++ b/crates/orchestrator/src/network_spec/node.rs
@@ -150,6 +150,13 @@ impl NodeSpec {
         let accounts = generators::generate_node_keys(&seed)?;
         let accounts = NodeAccounts { seed, accounts };
 
+        let db_snapshot = match (node_config.db_snapshot(), chain_context.default_db_snapshot) {
+            (Some(db_snapshot), _) => { Some(db_snapshot) },
+            (None, Some(db_snapshot)) => { Some(db_snapshot)},
+            _ => None,
+        };
+
+
         Ok(Self {
             name: node_config.name().to_string(),
             key,
@@ -170,7 +177,7 @@ impl NodeSpec {
                 .collect(),
             resources: node_config.resources().cloned(),
             p2p_cert_hash: node_config.p2p_cert_hash().map(str::to_string),
-            db_snapshot: node_config.db_snapshot().cloned(),
+            db_snapshot: db_snapshot.cloned(),
             accounts,
             ws_port: generators::generate_node_port(node_config.ws_port())?,
             rpc_port: generators::generate_node_port(node_config.rpc_port())?,

--- a/crates/orchestrator/src/network_spec/node.rs
+++ b/crates/orchestrator/src/network_spec/node.rs
@@ -151,11 +151,10 @@ impl NodeSpec {
         let accounts = NodeAccounts { seed, accounts };
 
         let db_snapshot = match (node_config.db_snapshot(), chain_context.default_db_snapshot) {
-            (Some(db_snapshot), _) => { Some(db_snapshot) },
-            (None, Some(db_snapshot)) => { Some(db_snapshot)},
+            (Some(db_snapshot), _) => Some(db_snapshot),
+            (None, Some(db_snapshot)) => Some(db_snapshot),
             _ => None,
         };
-
 
         Ok(Self {
             name: node_config.name().to_string(),

--- a/crates/orchestrator/src/spawner.rs
+++ b/crates/orchestrator/src/spawner.rs
@@ -156,7 +156,8 @@ where
                 .map(|var| (var.name.clone(), var.value.clone())),
         )
         .injected_files(files_to_inject)
-        .created_paths(created_paths);
+        .created_paths(created_paths)
+        .db_snapshot(node.db_snapshot.clone());
 
     let spawn_ops = if let Some(image) = node.image.as_ref() {
         spawn_ops.image(image.as_str())

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -39,6 +39,7 @@ tracing = { workspace = true }
 reqwest = { workspace = true }
 regex = { workspace = true }
 url = { workspace = true }
+flate2 = "1.0"
 
 # Zomebienet deps
 support = { workspace = true }

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -38,6 +38,7 @@ hex = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 regex = { workspace = true }
+url = { workspace = true }
 
 # Zomebienet deps
 support = { workspace = true }

--- a/crates/provider/src/kubernetes/namespace.rs
+++ b/crates/provider/src/kubernetes/namespace.rs
@@ -304,7 +304,6 @@ where
 
         Ok(())
     }
-
 }
 
 #[async_trait]

--- a/crates/provider/src/kubernetes/namespace.rs
+++ b/crates/provider/src/kubernetes/namespace.rs
@@ -304,6 +304,7 @@ where
 
         Ok(())
     }
+
 }
 
 #[async_trait]
@@ -348,6 +349,7 @@ where
             env: &options.env,
             startup_files: &options.injected_files,
             resources: options.resources.as_ref(),
+            db_snapshot: options.db_snapshot.as_ref(),
             k8s_client: &self.k8s_client,
             filesystem: &self.filesystem,
         })

--- a/crates/provider/src/kubernetes/node.rs
+++ b/crates/provider/src/kubernetes/node.rs
@@ -9,20 +9,21 @@ use std::{
 
 use anyhow::anyhow;
 use async_trait::async_trait;
-use configuration::shared::{constants::THIS_IS_A_BUG, resources::Resources};
+use configuration::{shared::{constants::THIS_IS_A_BUG, resources::Resources}, types::AssetLocation};
 use futures::future::try_join_all;
 use k8s_openapi::api::core::v1::{ServicePort, ServiceSpec};
+use sha2::Digest;
 use support::fs::FileSystem;
 use tokio::{sync::RwLock, task::JoinHandle, time::sleep, try_join};
+use tracing::trace;
+use url::Url;
 
 use super::{namespace::KubernetesNamespace, pod_spec_builder::PodSpecBuilder};
 use crate::{
     constants::{
         NODE_CONFIG_DIR, NODE_DATA_DIR, NODE_RELAY_DATA_DIR, NODE_SCRIPTS_DIR, P2P_PORT,
         PROMETHEUS_PORT, RPC_HTTP_PORT, RPC_WS_PORT,
-    },
-    types::{ExecutionResult, RunCommandOptions, RunScriptOptions, TransferedFile},
-    KubernetesClient, ProviderError, ProviderNamespace, ProviderNode,
+    }, types::{ExecutionResult, RunCommandOptions, RunScriptOptions, TransferedFile}, KubernetesClient, ProviderError, ProviderNamespace, ProviderNode
 };
 
 pub(super) struct KubernetesNodeOptions<'a, FS>
@@ -38,6 +39,7 @@ where
     pub(super) env: &'a [(String, String)],
     pub(super) startup_files: &'a [TransferedFile],
     pub(super) resources: Option<&'a Resources>,
+    pub(super) db_snapshot: Option<&'a AssetLocation>,
     pub(super) k8s_client: &'a KubernetesClient,
     pub(super) filesystem: &'a FS,
 }
@@ -114,6 +116,10 @@ where
             options.resources,
         )
         .await?;
+
+        if let Some(db_snap) = options.db_snapshot {
+            node.initialize_db_snapshot(db_snap).await?;
+        }
 
         node.initialize_startup_files(options.startup_files).await?;
 
@@ -216,6 +222,47 @@ where
         Ok(())
     }
 
+    async fn initialize_db_snapshot(&self, db_snapshot: &AssetLocation) -> Result<(), ProviderError> {
+        trace!("snap: {db_snapshot}");
+        let url_of_snap = match db_snapshot {
+            AssetLocation::Url(location) => { location.clone() },
+            AssetLocation::FilePath(filepath) => {
+                self.upload_to_fileserver(filepath).await?
+            },
+        };
+
+        // we need to get the snapshot from a public access
+        // and extract to /data
+        let opts = RunCommandOptions::new("mkdir")
+        .args(&[
+            "-p",
+            "/data/",
+            "&&",
+            "mkdir",
+            "-p",
+            "/relay-data/",
+            "&&",
+            // Use our version of curl
+            "/cfg/curl",
+            &url_of_snap.to_string(),
+            "--output",
+            "/data/db.tgz",
+            "&&",
+            "cd",
+            "/",
+            "&&",
+            "tar",
+            "--skip-old-files",
+            "-xzvf",
+            "/data/db.tgz"
+        ]);
+
+        trace!( "cmd opts: {:#?}", opts);
+        let _ = self.run_command(opts).await?;
+
+        Ok(())
+    }
+
     async fn initialize_startup_files(
         &self,
         startup_files: &[TransferedFile],
@@ -291,6 +338,37 @@ where
             .upgrade()
             .map(|namespace| namespace.name().to_string())
             .unwrap_or_else(|| panic!("namespace shouldn't be dropped, {}", THIS_IS_A_BUG))
+    }
+
+
+
+    async fn upload_to_fileserver(&self, location: &Path) -> Result<Url, ProviderError> {
+        let data = self.filesystem.read(location).await?;
+        let hashed_path = hex::encode(sha2::Sha256::digest(&data));
+        let req = self.http_client.head(format!("http://{}/{hashed_path}", self.file_server_local_host().await?)).build()
+        .map_err(|err| {
+            ProviderError::UploadFile(location.to_string_lossy().to_string(), err.into())
+        })?;
+
+        let url = req.url().clone();
+        let res = self.http_client.execute(req).await.map_err(|err| {
+            ProviderError::UploadFile(location.to_string_lossy().to_string(), err.into())
+        })?;
+
+        if res.status() != reqwest::StatusCode::OK {
+            // we need to upload the file
+            self.http_client
+            .post(url.as_ref())
+            .body(data)
+            .send()
+            .await
+            .map_err(|err| {
+                ProviderError::UploadFile(location.to_string_lossy().to_string(), err.into())
+            })?;
+
+        }
+
+        Ok(url)
     }
 
     async fn file_server_local_host(&self) -> Result<String, ProviderError> {

--- a/crates/provider/src/kubernetes/node.rs
+++ b/crates/provider/src/kubernetes/node.rs
@@ -9,7 +9,10 @@ use std::{
 
 use anyhow::anyhow;
 use async_trait::async_trait;
-use configuration::{shared::{constants::THIS_IS_A_BUG, resources::Resources}, types::AssetLocation};
+use configuration::{
+    shared::{constants::THIS_IS_A_BUG, resources::Resources},
+    types::AssetLocation,
+};
 use futures::future::try_join_all;
 use k8s_openapi::api::core::v1::{ServicePort, ServiceSpec};
 use sha2::Digest;
@@ -23,7 +26,9 @@ use crate::{
     constants::{
         NODE_CONFIG_DIR, NODE_DATA_DIR, NODE_RELAY_DATA_DIR, NODE_SCRIPTS_DIR, P2P_PORT,
         PROMETHEUS_PORT, RPC_HTTP_PORT, RPC_WS_PORT,
-    }, types::{ExecutionResult, RunCommandOptions, RunScriptOptions, TransferedFile}, KubernetesClient, ProviderError, ProviderNamespace, ProviderNode
+    },
+    types::{ExecutionResult, RunCommandOptions, RunScriptOptions, TransferedFile},
+    KubernetesClient, ProviderError, ProviderNamespace, ProviderNode,
 };
 
 pub(super) struct KubernetesNodeOptions<'a, FS>
@@ -222,19 +227,19 @@ where
         Ok(())
     }
 
-    async fn initialize_db_snapshot(&self, db_snapshot: &AssetLocation) -> Result<(), ProviderError> {
+    async fn initialize_db_snapshot(
+        &self,
+        db_snapshot: &AssetLocation,
+    ) -> Result<(), ProviderError> {
         trace!("snap: {db_snapshot}");
         let url_of_snap = match db_snapshot {
-            AssetLocation::Url(location) => { location.clone() },
-            AssetLocation::FilePath(filepath) => {
-                self.upload_to_fileserver(filepath).await?
-            },
+            AssetLocation::Url(location) => location.clone(),
+            AssetLocation::FilePath(filepath) => self.upload_to_fileserver(filepath).await?,
         };
 
         // we need to get the snapshot from a public access
         // and extract to /data
-        let opts = RunCommandOptions::new("mkdir")
-        .args(&[
+        let opts = RunCommandOptions::new("mkdir").args(&[
             "-p",
             "/data/",
             "&&",
@@ -254,10 +259,10 @@ where
             "tar",
             "--skip-old-files",
             "-xzvf",
-            "/data/db.tgz"
+            "/data/db.tgz",
         ]);
 
-        trace!( "cmd opts: {:#?}", opts);
+        trace!("cmd opts: {:#?}", opts);
         let _ = self.run_command(opts).await?;
 
         Ok(())
@@ -340,15 +345,19 @@ where
             .unwrap_or_else(|| panic!("namespace shouldn't be dropped, {}", THIS_IS_A_BUG))
     }
 
-
-
     async fn upload_to_fileserver(&self, location: &Path) -> Result<Url, ProviderError> {
         let data = self.filesystem.read(location).await?;
         let hashed_path = hex::encode(sha2::Sha256::digest(&data));
-        let req = self.http_client.head(format!("http://{}/{hashed_path}", self.file_server_local_host().await?)).build()
-        .map_err(|err| {
-            ProviderError::UploadFile(location.to_string_lossy().to_string(), err.into())
-        })?;
+        let req = self
+            .http_client
+            .head(format!(
+                "http://{}/{hashed_path}",
+                self.file_server_local_host().await?
+            ))
+            .build()
+            .map_err(|err| {
+                ProviderError::UploadFile(location.to_string_lossy().to_string(), err.into())
+            })?;
 
         let url = req.url().clone();
         let res = self.http_client.execute(req).await.map_err(|err| {
@@ -358,14 +367,13 @@ where
         if res.status() != reqwest::StatusCode::OK {
             // we need to upload the file
             self.http_client
-            .post(url.as_ref())
-            .body(data)
-            .send()
-            .await
-            .map_err(|err| {
-                ProviderError::UploadFile(location.to_string_lossy().to_string(), err.into())
-            })?;
-
+                .post(url.as_ref())
+                .body(data)
+                .send()
+                .await
+                .map_err(|err| {
+                    ProviderError::UploadFile(location.to_string_lossy().to_string(), err.into())
+                })?;
         }
 
         Ok(url)

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -95,6 +95,8 @@ pub enum ProviderError {
     #[error("Error uploading file: '{0}': {1}")]
     UploadFile(String, anyhow::Error),
 
+    #[error("Error downloading file: '{0}': {1}")]
+    DownloadFile(String, anyhow::Error),
 
     #[error("Error sending file: '{0}': {1}")]
     SendFile(String, anyhow::Error),

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -92,6 +92,10 @@ pub enum ProviderError {
     #[error("Failed to setup fileserver: {0}")]
     FileServerSetupError(anyhow::Error),
 
+    #[error("Error uploading file: '{0}': {1}")]
+    UploadFile(String, anyhow::Error),
+
+
     #[error("Error sending file: '{0}': {1}")]
     SendFile(String, anyhow::Error),
 

--- a/crates/provider/src/native/namespace.rs
+++ b/crates/provider/src/native/namespace.rs
@@ -100,6 +100,7 @@ where
             &options.env,
             &options.injected_files,
             &options.created_paths,
+            &options.db_snapshot.as_ref(),
             &self.filesystem,
         )
         .await?;

--- a/crates/provider/src/native/node.rs
+++ b/crates/provider/src/native/node.rs
@@ -1,18 +1,19 @@
 use std::{
-    path::{Path, PathBuf},
-    process::Stdio,
-    sync::{Arc, Weak},
-    time::Duration,
+    path::{Path, PathBuf}, process::Stdio, sync::{Arc, Weak}, time::Duration
 };
 
 use anyhow::anyhow;
 use async_trait::async_trait;
+use configuration::{shared::constants::THIS_IS_A_BUG, types::AssetLocation};
+use flate2::read::GzDecoder;
 use futures::future::try_join_all;
 use nix::{
     sys::signal::{kill, Signal},
     unistd::Pid,
 };
+use sha2::Digest;
 use support::fs::FileSystem;
+use tar::Archive;
 use tokio::{
     io::{AsyncRead, AsyncReadExt, BufReader},
     process::{Child, ChildStderr, ChildStdout, Command},
@@ -28,9 +29,7 @@ use tracing::trace;
 
 use super::namespace::NativeNamespace;
 use crate::{
-    constants::{NODE_CONFIG_DIR, NODE_DATA_DIR, NODE_RELAY_DATA_DIR, NODE_SCRIPTS_DIR},
-    types::{ExecutionResult, RunCommandOptions, RunScriptOptions, TransferedFile},
-    ProviderError, ProviderNode,
+    constants::{NODE_CONFIG_DIR, NODE_DATA_DIR, NODE_RELAY_DATA_DIR, NODE_SCRIPTS_DIR}, types::{ExecutionResult, RunCommandOptions, RunScriptOptions, TransferedFile}, ProviderError, ProviderNamespace, ProviderNode
 };
 
 pub(super) struct NativeNode<FS>
@@ -69,6 +68,7 @@ where
         env: &[(String, String)],
         startup_files: &[TransferedFile],
         created_paths: &[PathBuf],
+        db_snapshot: &Option<&AssetLocation>,
         filesystem: &FS,
     ) -> Result<Arc<Self>, ProviderError> {
         let base_dir = PathBuf::from_iter([namespace_base_dir, &PathBuf::from(name)]);
@@ -114,6 +114,10 @@ where
         node.initialize_startup_paths(created_paths).await?;
         node.initialize_startup_files(startup_files).await?;
 
+        if let Some(db_snap) = db_snapshot {
+           node.initialize_db_snapshot(db_snap).await?;
+        }
+
         let (stdout, stderr) = node.initialize_process().await?;
 
         node.initialize_log_writing(stdout, stderr).await;
@@ -146,6 +150,56 @@ where
         )
         .await?;
         trace!("files created!");
+
+        Ok(())
+    }
+
+    async fn initialize_db_snapshot(&self, db_snapshot: &AssetLocation) -> Result<(), ProviderError> {
+        trace!("snap: {db_snapshot}");
+
+        // check if we need to get the db or is already in the ns
+        let ns_base_dir = self.namespace_base_dir();
+        let hashed_location = match db_snapshot {
+            AssetLocation::Url(location) => {
+                hex::encode(sha2::Sha256::digest(&location.to_string()))
+            },
+            AssetLocation::FilePath(filepath) => {
+                hex::encode(sha2::Sha256::digest(&filepath.to_string_lossy().to_string()))
+            }
+        };
+
+        let full_path = format!("{}/{}.tgz", ns_base_dir, hashed_location );
+        trace!("db_snap fullpath in ns: {full_path}");
+        if ! self.filesystem.exists(&full_path).await {
+            // needs to download/copy
+            self.get_db_snapshot(db_snapshot, &full_path).await?;
+        }
+
+        let contents  =self.filesystem.read(full_path).await.unwrap();
+        let gz = GzDecoder::new(&contents[..]);
+        let mut archive = Archive::new(gz);
+        archive.unpack(self.base_dir.to_string_lossy().as_ref()).unwrap();
+
+        Ok(())
+    }
+
+    async fn get_db_snapshot(&self, location: &AssetLocation, full_path: &str) -> Result<(), ProviderError> {
+        trace!("getting db_snapshot from: {:?} to: {full_path}", location);
+        match location {
+            AssetLocation::Url(location) => {
+                let res = reqwest::get(location.as_ref())
+                .await
+                .map_err(|err| ProviderError::DownloadFile(location.to_string(), err.into()))?;
+
+                let contents: &[u8] = &res.bytes().await.unwrap();
+                trace!("writing: {full_path}");
+                self.filesystem.write( full_path, contents).await?;
+
+            },
+            AssetLocation::FilePath(filepath) => {
+                self.filesystem.copy( filepath, full_path).await?;
+            },
+        };
 
         Ok(())
     }
@@ -270,6 +324,13 @@ where
             .await?;
 
         Ok(())
+    }
+
+    fn namespace_base_dir(&self) -> String {
+        self.namespace
+            .upgrade()
+            .map(|namespace| namespace.base_dir().to_string_lossy().to_string())
+            .unwrap_or_else(|| panic!("namespace shouldn't be dropped, {}", THIS_IS_A_BUG))
     }
 }
 

--- a/crates/provider/src/shared/types.rs
+++ b/crates/provider/src/shared/types.rs
@@ -3,7 +3,7 @@ use std::{
     process::ExitStatus,
 };
 
-use configuration::shared::resources::Resources;
+use configuration::{shared::resources::Resources, types::AssetLocation};
 
 pub type Port = u16;
 
@@ -25,18 +25,28 @@ pub struct ProviderCapabilities {
 
 #[derive(Debug, Clone)]
 pub struct SpawnNodeOptions {
+    /// Name of the node
     pub name: String,
+    /// Image of the node (IFF is supported by the provider)
     pub image: Option<String>,
+    /// Resources to apply to the node (IFF is supported by the provider)
     pub resources: Option<Resources>,
+    /// Main command to execute
     pub program: String,
+    /// Arguments to pass to the main command
     pub args: Vec<String>,
+    /// Environment to set when runnning the `program`
     pub env: Vec<(String, String)>,
     // TODO: rename startup_files
+    /// Files to inject at startup
     pub injected_files: Vec<TransferedFile>,
     /// Paths to create before start the node (e.g keystore)
     /// should be created with `create_dir_all` in order
     /// to create the full path even when we have missing parts
     pub created_paths: Vec<PathBuf>,
+    /// Database snapshot to be injected (should be a tgz file)
+    /// Could be a local or remote asset
+    pub db_snapshot: Option<AssetLocation>
 }
 
 impl SpawnNodeOptions {
@@ -53,6 +63,7 @@ impl SpawnNodeOptions {
             env: vec![],
             injected_files: vec![],
             created_paths: vec![],
+            db_snapshot: None
         }
     }
 
@@ -66,6 +77,12 @@ impl SpawnNodeOptions {
 
     pub fn resources(mut self, resources: Resources) -> Self {
         self.resources = Some(resources);
+        self
+    }
+
+    pub fn db_snapshot(mut self, db_snap: Option<AssetLocation>) -> Self
+    {
+        self.db_snapshot = db_snap;
         self
     }
 
@@ -215,6 +232,7 @@ impl GenerateFilesOptions {
     }
 }
 
+#[derive(Debug)]
 pub struct RunCommandOptions {
     pub program: String,
     pub args: Vec<String>,

--- a/crates/provider/src/shared/types.rs
+++ b/crates/provider/src/shared/types.rs
@@ -46,7 +46,7 @@ pub struct SpawnNodeOptions {
     pub created_paths: Vec<PathBuf>,
     /// Database snapshot to be injected (should be a tgz file)
     /// Could be a local or remote asset
-    pub db_snapshot: Option<AssetLocation>
+    pub db_snapshot: Option<AssetLocation>,
 }
 
 impl SpawnNodeOptions {
@@ -63,7 +63,7 @@ impl SpawnNodeOptions {
             env: vec![],
             injected_files: vec![],
             created_paths: vec![],
-            db_snapshot: None
+            db_snapshot: None,
         }
     }
 
@@ -80,8 +80,7 @@ impl SpawnNodeOptions {
         self
     }
 
-    pub fn db_snapshot(mut self, db_snap: Option<AssetLocation>) -> Self
-    {
+    pub fn db_snapshot(mut self, db_snap: Option<AssetLocation>) -> Self {
         self.db_snapshot = db_snap;
         self
     }


### PR DESCRIPTION
Add:
 - Logic to use db_snapshot in both native/k8s providers
 - Small fix on chain_spec_path (for both native/k8s)
 - New example `db_snapshot`