### PR TITLE
Make builders accept `impl FnOnce` instead of `fn`

### DIFF
--- a/crates/configuration/src/parachain.rs
+++ b/crates/configuration/src/parachain.rs
@@ -496,7 +496,10 @@ impl<C: Context> ParachainConfigBuilder<WithId, C> {
     }
 
     /// Set the default resources limits used for collators. Can be overridden.
-    pub fn with_default_resources(self, f: fn(ResourcesBuilder) -> ResourcesBuilder) -> Self {
+    pub fn with_default_resources(
+        self,
+        f: impl FnOnce(ResourcesBuilder) -> ResourcesBuilder,
+    ) -> Self {
         match f(ResourcesBuilder::new()).build() {
             Ok(default_resources) => Self::transition(
                 ParachainConfig {
@@ -687,7 +690,7 @@ impl<C: Context> ParachainConfigBuilder<WithId, C> {
     /// Add a new collator using a nested [`NodeConfigBuilder`].
     pub fn with_collator(
         self,
-        f: fn(NodeConfigBuilder<node::Initial>) -> NodeConfigBuilder<node::Buildable>,
+        f: impl FnOnce(NodeConfigBuilder<node::Initial>) -> NodeConfigBuilder<node::Buildable>,
     ) -> ParachainConfigBuilder<WithAtLeastOneCollator, C> {
         match f(NodeConfigBuilder::new(
             self.default_chain_context(),
@@ -722,7 +725,7 @@ impl<C: Context> ParachainConfigBuilder<WithAtLeastOneCollator, C> {
     /// Add a new collator using a nested [`NodeConfigBuilder`].
     pub fn with_collator(
         self,
-        f: fn(NodeConfigBuilder<node::Initial>) -> NodeConfigBuilder<node::Buildable>,
+        f: impl FnOnce(NodeConfigBuilder<node::Initial>) -> NodeConfigBuilder<node::Buildable>,
     ) -> Self {
         match f(NodeConfigBuilder::new(
             ChainDefaultContext::default(),

--- a/crates/configuration/src/relaychain.rs
+++ b/crates/configuration/src/relaychain.rs
@@ -250,7 +250,10 @@ impl RelaychainConfigBuilder<WithChain> {
     }
 
     /// Set the default resources limits used for nodes. Can be overridden.
-    pub fn with_default_resources(self, f: fn(ResourcesBuilder) -> ResourcesBuilder) -> Self {
+    pub fn with_default_resources(
+        self,
+        f: impl FnOnce(ResourcesBuilder) -> ResourcesBuilder,
+    ) -> Self {
         match f(ResourcesBuilder::new()).build() {
             Ok(default_resources) => Self::transition(
                 RelaychainConfig {
@@ -349,7 +352,7 @@ impl RelaychainConfigBuilder<WithChain> {
     /// Add a new node using a nested [`NodeConfigBuilder`].
     pub fn with_node(
         self,
-        f: fn(NodeConfigBuilder<node::Initial>) -> NodeConfigBuilder<node::Buildable>,
+        f: impl FnOnce(NodeConfigBuilder<node::Initial>) -> NodeConfigBuilder<node::Buildable>,
     ) -> RelaychainConfigBuilder<WithAtLeastOneNode> {
         match f(NodeConfigBuilder::new(
             self.default_chain_context(),
@@ -384,7 +387,7 @@ impl RelaychainConfigBuilder<WithAtLeastOneNode> {
     /// Add a new node using a nested [`NodeConfigBuilder`].
     pub fn with_node(
         self,
-        f: fn(NodeConfigBuilder<node::Initial>) -> NodeConfigBuilder<node::Buildable>,
+        f: impl FnOnce(NodeConfigBuilder<node::Initial>) -> NodeConfigBuilder<node::Buildable>,
     ) -> Self {
         match f(NodeConfigBuilder::new(
             self.default_chain_context(),

--- a/crates/configuration/src/shared/node.rs
+++ b/crates/configuration/src/shared/node.rs
@@ -530,7 +530,7 @@ impl NodeConfigBuilder<Buildable> {
     }
 
     /// Set the resources limits what will be used for the node (only podman/k8s). Override the default.
-    pub fn with_resources(self, f: fn(ResourcesBuilder) -> ResourcesBuilder) -> Self {
+    pub fn with_resources(self, f: impl FnOnce(ResourcesBuilder) -> ResourcesBuilder) -> Self {
         match f(ResourcesBuilder::new()).build() {
             Ok(resources) => Self::transition(
                 NodeConfig {


### PR DESCRIPTION
A follow-up of #171 with the same motivation.