### PR TITLE
Fix argument passing

### DIFF
--- a/crates/orchestrator/src/generators/command.rs
+++ b/crates/orchestrator/src/generators/command.rs
@@ -121,7 +121,7 @@ pub fn generate_for_cumulus_node(
                 if FLAGS_ADDED_BY_US.contains(&flag.as_str()) {
                     None
                 } else {
-                    Some(flag.to_owned())
+                    Some(vec![flag.to_owned()])
                 }
             },
             Arg::Option(k, v) => {
@@ -131,11 +131,11 @@ pub fn generate_for_cumulus_node(
                     full_node_p2p_needs_to_be_injected = true;
                     None
                 } else {
-                    let kv_str = format!("{} {}", k, v);
-                    Some(kv_str)
+                    Some(vec![k.to_owned(), v.to_owned()])
                 }
             },
         })
+        .flatten()
         .collect::<Vec<String>>();
 
     // change p2p port if is the default
@@ -149,18 +149,18 @@ pub fn generate_for_cumulus_node(
                 if FLAGS_ADDED_BY_US.contains(&flag.as_str()) {
                     None
                 } else {
-                    Some(flag.to_owned())
+                    Some(vec![flag.to_owned()])
                 }
             },
             Arg::Option(k, v) => {
                 if OPS_ADDED_BY_US.contains(&k.as_str()) {
                     None
                 } else {
-                    let kv_str = format!("{} {}", k, v);
-                    Some(kv_str)
+                    Some(vec![k.to_owned(), v.to_owned()])
                 }
             },
         })
+        .flatten()
         .collect::<Vec<String>>();
 
     tmp_args.append(&mut args_filtered);
@@ -318,18 +318,18 @@ pub fn generate_for_node(
                 if FLAGS_ADDED_BY_US.contains(&flag.as_str()) {
                     None
                 } else {
-                    Some(flag.to_owned())
+                    Some(vec![flag.to_owned()])
                 }
             },
             Arg::Option(k, v) => {
                 if OPS_ADDED_BY_US.contains(&k.as_str()) {
                     None
                 } else {
-                    let kv_str = format!("{} {}", k, v);
-                    Some(kv_str)
+                    Some(vec![k.to_owned(), v.to_owned()])
                 }
             },
         })
+        .flatten()
         .collect::<Vec<String>>();
 
     tmp_args.append(&mut args_filtered);


### PR DESCRIPTION
Concatenating the command line option and its value doesn't really work. The shell treats `--opt val` as a single argument `--opt val` instead of `--opt` `val` and fails to execute. This PR fixes that by separating options from their values.

Error example:
```
error: unexpected argument '--workers-path ~/.cargo/bin/workers-1.6' found

  tip: a similar argument exists: '--workers-path'
```