### PR TITLE
fix: comment test-runner and fix docs link

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Create docs
         run: |
           cargo doc --no-deps
-          echo "<meta http-equiv=\"refresh\" content=\"0; url=configuration\">" > target/doc/index.html
+          echo "<meta http-equiv=\"refresh\" content=\"0; url=zombienet_sdk\">" > target/doc/index.html
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
   "crates/configuration",
   "crates/orchestrator",
   "crates/provider",
-  "crates/test-runner",
+  #"crates/test-runner",
   "crates/prom-metrics-parser",
   "crates/file-server"
 ]


### PR DESCRIPTION
Small fix 
- exclude the `test-runner` from the workspace (for now)
- Change docs links to point to `sdk`