### PR TITLE
[WIP] Allow to respawn node with different set of arguments

### DIFF
--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(dead_code, clippy::expect_fun_call)]
 
 pub mod errors;
-mod generators;
+pub mod generators;
 pub mod network;
 mod network_helper;
 mod network_spec;
@@ -252,7 +252,7 @@ where
                     } else {
                         node.spec.p2p_port.0
                     },
-                    node.inner.args().as_ref(),
+                    node.inner.args().await.as_ref(),
                     &node.spec.p2p_cert_hash,
                 )?,
             );

--- a/crates/orchestrator/src/network/node.rs
+++ b/crates/orchestrator/src/network/node.rs
@@ -118,6 +118,11 @@ impl NetworkNode {
         Ok(())
     }
 
+    pub async fn kill(&self) -> Result<(), anyhow::Error> {
+        self.inner.kill().await?;
+        Ok(())
+    }
+
     /// Restart the node using the same `cmd`, `args` and `env` (and same isolated dir)
     pub async fn restart(&self, after: Option<Duration>) -> Result<(), anyhow::Error> {
         self.inner.restart(after).await?;

--- a/crates/orchestrator/src/network_spec/node.rs
+++ b/crates/orchestrator/src/network_spec/node.rs
@@ -50,10 +50,10 @@ pub struct NodeSpec {
     pub(crate) name: String,
 
     /// Node key, used for compute the p2p identity.
-    pub(crate) key: String,
+    pub key: String,
 
     // libp2p local identity
-    pub(crate) peer_id: String,
+    pub peer_id: String,
 
     /// Accounts to be injected in the keystore.
     pub(crate) accounts: NodeAccounts,

--- a/crates/provider/src/kubernetes/namespace.rs
+++ b/crates/provider/src/kubernetes/namespace.rs
@@ -418,6 +418,14 @@ where
         Ok(node)
     }
 
+    async fn respawn_node(
+        &self,
+        _name: &str,
+        _args: Vec<String>,
+    ) -> Result<DynNode, ProviderError> {
+        todo!()
+    }
+
     async fn generate_files(&self, options: GenerateFilesOptions) -> Result<(), ProviderError> {
         debug!("options {:#?}", options);
 

--- a/crates/provider/src/kubernetes/node.rs
+++ b/crates/provider/src/kubernetes/node.rs
@@ -401,8 +401,8 @@ where
         &self.name
     }
 
-    fn args(&self) -> Vec<&str> {
-        self.args.iter().map(|arg| arg.as_str()).collect()
+    async fn args(&self) -> Vec<String> {
+        self.args.clone()
     }
 
     fn base_dir(&self) -> &PathBuf {
@@ -654,6 +654,14 @@ where
             })?;
 
         Ok(())
+    }
+
+    async fn kill(&self) -> Result<(), ProviderError> {
+        todo!()
+    }
+
+    async fn respawn(&self) -> Result<(), ProviderError> {
+        todo!()
     }
 
     async fn restart(&self, after: Option<Duration>) -> Result<(), ProviderError> {

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -147,6 +147,8 @@ pub trait ProviderNamespace {
 
     async fn spawn_node(&self, options: &SpawnNodeOptions) -> Result<DynNode, ProviderError>;
 
+    async fn respawn_node(&self, name: &str, args: Vec<String>) -> Result<DynNode, ProviderError>;
+
     async fn generate_files(&self, options: GenerateFilesOptions) -> Result<(), ProviderError>;
 
     async fn destroy(&self) -> Result<(), ProviderError>;
@@ -160,7 +162,7 @@ pub type DynNamespace = Arc<dyn ProviderNamespace + Send + Sync>;
 pub trait ProviderNode {
     fn name(&self) -> &str;
 
-    fn args(&self) -> Vec<&str>;
+    async fn args(&self) -> Vec<String>;
 
     fn base_dir(&self) -> &PathBuf;
 
@@ -220,6 +222,10 @@ pub trait ProviderNode {
     async fn pause(&self) -> Result<(), ProviderError>;
 
     async fn resume(&self) -> Result<(), ProviderError>;
+
+    async fn kill(&self) -> Result<(), ProviderError>;
+
+    async fn respawn(&self) -> Result<(), ProviderError>;
 
     async fn restart(&self, after: Option<Duration>) -> Result<(), ProviderError>;
 

--- a/crates/provider/src/native/namespace.rs
+++ b/crates/provider/src/native/namespace.rs
@@ -134,6 +134,19 @@ where
         Ok(node)
     }
 
+    async fn respawn_node(&self, name: &str, args: Vec<String>) -> Result<DynNode, ProviderError> {
+        let nodes = self.nodes.read().await;
+
+        let node = nodes
+            .get(&name.to_owned())
+            .ok_or(ProviderError::MissingNode(name.to_owned()))?
+            .clone();
+        node.set_args(&args).await;
+        node.respawn().await?;
+
+        Ok(node)
+    }
+
     async fn generate_files(&self, options: GenerateFilesOptions) -> Result<(), ProviderError> {
         let node_name = if let Some(name) = options.temp_name {
             name


### PR DESCRIPTION
I made these changes while researching a quite specific use case. Not all of them may be useful for the general public, but I believe some of them may.

Everything is implemented for the native provider only at the moment. I currently lack the expertise to implement it for Kubernetes.

It also introduces changes in publicly exposed interfaces, so that should be considered a breaking change.

An approximate list of what's been done and why:
* Got rid of `nodes_by_name` hashmap in the `orchestrator::Network`. It didn't make sense from the POV of performance (as a zombienet is unlikely to be of size exceeding a couple of hundreds of nodes), but cloning structures around was effectively sealing the network at the moment it was spawned, not allowing to change it dynamically;
* Fixed a bug which resulted in double-adding nodes to `network::network::Relaychain` and `network::network::Parachain` when a new validator or collator is added;
* Introduced a call allowing to kill a node without restarting it;
* Introduced a call allowing to re-spawn a previously killed node, altering its spec between the kill and the re-spawn;
* Implemented means of dynamically replacing the node inside a network.

Thoughts and ideas:
* Narrowing down the use case to changing node command line arguments during the restart is a decision dictated by my specific research. Probably, it may be generalized to like "change everything you want while the node is dead", but the scope of the allowed changes has to be discussed;
* The overall approach is somewhat brittle and not that foolproof. It would be better to have something like `pub async fn restart_with(&mut self, mutate: impl FnMut(&mut NetworkNode))` that would kill the node, run the closure to alter its configuration, and then re-spawn the node, but that gives less leverage to the developer. This needs to be discussed as well.

I'll add a usage example a bit later. Feel free to ask questions, provide suggestions, etc.