### PR TITLE
fix(orchestrator): compute args_output in add_node/collator

### DIFF
--- a/crates/orchestrator/src/network.rs
+++ b/crates/orchestrator/src/network.rs
@@ -144,8 +144,15 @@ impl<T: FileSystem> Network<T> {
             default_args: self.initial_spec.relaychain.default_args.iter().collect(),
         };
 
-        let node_spec =
+        let mut node_spec =
             network_spec::node::NodeSpec::from_ad_hoc(&name, options.into(), &chain_context)?;
+
+        node_spec.available_args_output = Some(
+            self.initial_spec
+                .node_available_args_output(&node_spec, self.ns.clone())
+                .await?,
+        );
+
         let base_dir = self.ns.base_dir().to_string_lossy();
         let scoped_fs = ScopedFilesystem::new(&self.filesystem, &base_dir);
 
@@ -288,8 +295,14 @@ impl<T: FileSystem> Network<T> {
             ));
         }
 
-        let node_spec =
+        let mut node_spec =
             network_spec::node::NodeSpec::from_ad_hoc(name.into(), options.into(), &chain_context)?;
+
+        node_spec.available_args_output = Some(
+            self.initial_spec
+                .node_available_args_output(&node_spec, self.ns.clone())
+                .await?,
+        );
 
         let node = spawner::spawn_node(&node_spec, global_files_to_inject, &ctx).await?;
         let para = self.parachains.get_mut(&para_id).unwrap();

--- a/crates/sdk/tests/smoke.rs
+++ b/crates/sdk/tests/smoke.rs
@@ -6,6 +6,7 @@ use std::{
 
 use configuration::{NetworkConfig, NetworkConfigBuilder};
 use futures::{stream::StreamExt, Future};
+use orchestrator::{AddCollatorOptions, AddNodeOptions};
 use serde_json::json;
 use support::fs::local::LocalFileSystem;
 use zombienet_sdk::{Network, NetworkConfigExt, OrchestratorError, PROVIDERS};
@@ -57,7 +58,6 @@ async fn ci_k8s_basic_functionalities_should_works() {
     let config = small_network();
     let spawn_fn = get_spawn_fn();
 
-    #[allow(unused_mut)]
     let mut network = spawn_fn(config).await.unwrap();
     // Optionally detach the network
     // network.detach().await;
@@ -128,6 +128,31 @@ async fn ci_k8s_basic_functionalities_should_works() {
     while let Some(block) = blocks.next().await {
         println!("Block (para) #{}", block.unwrap().header().number);
     }
+
+    // add node
+    let opts = AddNodeOptions {
+        rpc_port: Some(9444),
+        is_validator: true,
+        ..Default::default()
+    };
+
+    network.add_node("new1", opts).await.unwrap();
+
+    // add collator
+    let col_opts = AddCollatorOptions {
+        command: Some("polkadot-parachain".try_into().unwrap()),
+        image: Some(
+            "docker.io/parity/polkadot-parachain:1.7.0"
+                .try_into()
+                .unwrap(),
+        ),
+        ..Default::default()
+    };
+
+    network
+        .add_collator("new-col-1", col_opts, 2000)
+        .await
+        .unwrap();
 
     // tear down (optional if you don't detach the network)
     // network.destroy().await.unwrap();


### PR DESCRIPTION
fix #194 

Add logic to compute the args_output (if needed) for add_node/add_collator.
