### PR TITLE
feat: enhance public api

### DIFF
--- a/crates/orchestrator/src/errors.rs
+++ b/crates/orchestrator/src/errors.rs
@@ -18,7 +18,7 @@ pub enum OrchestratorError {
     InvariantError(&'static str),
     #[error("Global network spawn timeout: {0} secs")]
     GlobalTimeOut(u32),
-    #[error("Generator error")]
+    #[error("Generator error: {0}")]
     GeneratorError(#[from] generators::errors::GeneratorError),
     #[error("Provider error")]
     ProviderError(#[from] ProviderError),

--- a/crates/orchestrator/src/generators/command.rs
+++ b/crates/orchestrator/src/generators/command.rs
@@ -99,7 +99,10 @@ pub fn generate_for_cumulus_node(
             Arg::Option(..) => false,
         }) {
             (collator_args, full_node_args) = args.split_at(index);
-        };
+        } else {
+            // Assume args are those specified for collator only
+            collator_args = args;
+        }
     }
 
     // set our base path

--- a/crates/orchestrator/src/generators/errors.rs
+++ b/crates/orchestrator/src/generators/errors.rs
@@ -9,7 +9,7 @@ pub enum GeneratorError {
     PortGeneration(u16, String),
     #[error("Chain-spec build error: {0}")]
     ChainSpecGeneration(String),
-    #[error("Provider error")]
+    #[error("Provider error: {0}")]
     ProviderError(#[from] ProviderError),
     #[error("FileSystem error")]
     FileSystemError(#[from] FileSystemError),

--- a/crates/orchestrator/src/generators/para_artifact.rs
+++ b/crates/orchestrator/src/generators/para_artifact.rs
@@ -69,6 +69,7 @@ impl ParaArtifact {
             ParaArtifactBuildOption::Path(path) => {
                 let t = TransferedFile::new(PathBuf::from(path), artifact_path.as_ref().into());
                 scoped_fs.copy_files(vec![&t]).await?;
+                self.artifact_path = Some(artifact_path.as_ref().into());
             },
             ParaArtifactBuildOption::Command(cmd) => {
                 let generate_subcmd = match self.artifact_type {

--- a/crates/orchestrator/src/network.rs
+++ b/crates/orchestrator/src/network.rs
@@ -77,6 +77,10 @@ impl<T: FileSystem> Network<T> {
         self.ns.name().to_string()
     }
 
+    pub fn base_dir(&self) -> Option<&str> {
+        self.ns.base_dir().to_str()
+    }
+
     pub fn relaychain(&self) -> &Relaychain {
         &self.relay
     }
@@ -562,7 +566,7 @@ impl<T: FileSystem> Network<T> {
         self.parachains.get(&para_id)
     }
 
-    pub(crate) fn parachains(&self) -> Vec<&Parachain> {
+    pub fn parachains(&self) -> Vec<&Parachain> {
         self.parachains.values().collect()
     }
 

--- a/crates/orchestrator/src/network/node.rs
+++ b/crates/orchestrator/src/network/node.rs
@@ -42,6 +42,14 @@ impl NetworkNode {
         }
     }
 
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn args(&self) -> Vec<&str> {
+        self.inner.args()
+    }
+
     pub fn spec(&self) -> &NodeSpec {
         &self.spec
     }

--- a/crates/orchestrator/src/network/parachain.rs
+++ b/crates/orchestrator/src/network/parachain.rs
@@ -167,6 +167,18 @@ impl Parachain {
 
         Ok(())
     }
+
+    pub fn para_id(&self) -> u32 {
+        self.para_id
+    }
+
+    pub fn chain_id(&self) -> Option<&str> {
+        self.chain_id.as_deref()
+    }
+
+    pub fn collators(&self) -> Vec<&NetworkNode> {
+        self.collators.iter().collect()
+    }
 }
 
 #[cfg(test)]

--- a/crates/orchestrator/src/network/relaychain.rs
+++ b/crates/orchestrator/src/network/relaychain.rs
@@ -24,4 +24,8 @@ impl Relaychain {
     pub fn chain(&self) -> &str {
         &self.chain
     }
+
+    pub fn nodes(&self) -> Vec<&NetworkNode> {
+        self.nodes.iter().collect()
+    }
 }

--- a/crates/orchestrator/src/network_spec/node.rs
+++ b/crates/orchestrator/src/network_spec/node.rs
@@ -275,4 +275,8 @@ impl NodeSpec {
             ))
             .contains(arg.as_ref())
     }
+
+    pub fn command(&self) -> &str {
+        self.command.as_str()
+    }
 }


### PR DESCRIPTION
Firstly, thank you for an amazing library! The original zombienet is a Polkadot staple and now being able to use it completely from Rust is a game changer for us: as you may be aware, we have integrated zombienet-sdk with [pop-cli](https://github.com/paritytech/zombienet-sdk).

In doing so, we needed to add a few getters to the public api to be able to present certain information to the user, as well we expose a little more of the inner errors. This PR simply upstreams these changes.

It also includes two additional fixes, which may be better implemented based on your guidance:
- collator args werent working for us when specified in a config file, which seemed to be due to missing `--` in the args list provided by calling functions. 
- artifact path wasnt set when trying to build a chain spec. This may no longer be required based on the changes in https://github.com/paritytech/zombienet-sdk/commit/c7ce50c0e54c7efd505d18c0d77fe169f7df0465

I am happy to add tests if you are open to these changes. 🙂