### PR TITLE
feat: add environment helper

### DIFF
--- a/crates/sdk/src/environment.rs
+++ b/crates/sdk/src/environment.rs
@@ -1,0 +1,51 @@
+//! Helpers functions to get configuration (e.g. Provider and images) from the env vars
+use std::{env, future::Future, pin::Pin};
+
+use crate::{LocalFileSystem, Network, NetworkConfig, NetworkConfigExt, OrchestratorError};
+
+const DEFAULT_POLKADOT_IMAGE: &str = "docker.io/parity/polkadot:latest";
+const DEFAULT_CUMULUS_IMAGE: &str = "docker.io/parity/polkadot-parachain:latest";
+
+#[derive(Debug, Default)]
+pub struct Images {
+    pub polkadot: String,
+    pub cumulus: String,
+}
+
+pub enum Provider {
+    Native,
+    K8s,
+    Docker,
+}
+
+// Use `docker` as default provider
+impl From<String> for Provider {
+    fn from(value: String) -> Self {
+        match value.to_ascii_lowercase().as_ref() {
+            "native" => Provider::Native,
+            "k8s" => Provider::K8s,
+            _ => Provider::Docker, // default provider
+        }
+    }
+}
+
+pub fn get_images_from_env() -> Images {
+    let polkadot = env::var("POLKADOT_IMAGE").unwrap_or(DEFAULT_POLKADOT_IMAGE.into());
+    let cumulus = env::var("CUMULUS_IMAGE").unwrap_or(DEFAULT_CUMULUS_IMAGE.into());
+    Images { polkadot, cumulus }
+}
+
+pub fn get_provider_from_env() -> Provider {
+    env::var("ZOMBIE_PROVIDER").unwrap_or_default().into()
+}
+
+pub type SpawnResult = Result<Network<LocalFileSystem>, OrchestratorError>;
+pub fn get_spawn_fn() -> fn(NetworkConfig) -> Pin<Box<dyn Future<Output = SpawnResult> + Send>> {
+    let provider = get_provider_from_env();
+
+    match provider {
+        Provider::Native => NetworkConfigExt::spawn_native,
+        Provider::K8s => NetworkConfigExt::spawn_k8s,
+        Provider::Docker => NetworkConfigExt::spawn_docker,
+    }
+}

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -10,7 +10,8 @@ pub use orchestrator::{
 use provider::{DockerProvider, KubernetesProvider, NativeProvider};
 pub use support::fs::local::LocalFileSystem;
 
-pub const PROVIDERS: [&str; 2] = ["k8s", "native"];
+pub mod environment;
+pub const PROVIDERS: [&str; 3] = ["k8s", "native", "docker"];
 
 #[async_trait]
 pub trait NetworkConfigExt {

--- a/crates/sdk/tests/smoke.rs
+++ b/crates/sdk/tests/smoke.rs
@@ -1,11 +1,10 @@
-use std::{env, pin::Pin, time::Instant};
+use std::time::Instant;
 
 use configuration::{NetworkConfig, NetworkConfigBuilder};
-use futures::{stream::StreamExt, Future};
+use futures::stream::StreamExt;
 use orchestrator::{AddCollatorOptions, AddNodeOptions};
 use serde_json::json;
-use support::fs::local::LocalFileSystem;
-use zombienet_sdk::{Network, NetworkConfigExt, OrchestratorError, PROVIDERS};
+use zombienet_sdk::environment::get_spawn_fn;
 
 fn small_network() -> NetworkConfig {
     NetworkConfigBuilder::new()
@@ -25,25 +24,6 @@ fn small_network() -> NetworkConfig {
         })
         .build()
         .unwrap()
-}
-
-type SpawnResult = Result<Network<LocalFileSystem>, OrchestratorError>;
-fn get_spawn_fn() -> fn(NetworkConfig) -> Pin<Box<dyn Future<Output = SpawnResult> + Send>> {
-    const PROVIDER_KEY: &str = "ZOMBIE_PROVIDER";
-    let provider = env::var(PROVIDER_KEY).unwrap_or(String::from("k8s"));
-    assert!(
-        PROVIDERS.contains(&provider.as_str()),
-        "\n❌ Invalid provider, available options {}\n",
-        PROVIDERS.join(", ")
-    );
-
-    // TODO: revisit this
-
-    if provider == "k8s" {
-        zombienet_sdk::NetworkConfig::spawn_k8s
-    } else {
-        zombienet_sdk::NetworkConfig::spawn_native
-    }
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Add environment helpers

example
```rs
...
    let spawn_fn = get_spawn_fn();
    let mut network = spawn_fn(config).await?;
```

Env vars used:

`ZOMBIE_PROVIDER`: could be `k8s`, `native`, `docker` (default)

Also, includes a helper to read the `images` from env

`get_images_from_env` use: 

`POLKADOT_IMAGE`:(docker.io/parity/polkadot:latest)
`CUMULUS_IMAGE`:(docker.io/parity/polkadot-parachain:latest)

Thx!