### PR TITLE
chore: bump version for release `v0.2.5`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.2.4"
+version = "0.2.5"
 rust-version = "1.70.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/zombienet-sdk"
@@ -58,9 +58,9 @@ tower-http = { version = "0.5" }
 tracing-subscriber = { version = "0.3" }
 
 # Zombienet workspace crates:
-support = { package = "zombienet-support", version = "0.2.4", path = "crates/support" }
-configuration = { package = "zombienet-configuration", version = "0.2.4", path = "crates/configuration" }
-orchestrator = { package = "zombienet-orchestrator", version = "0.2.4", path = "crates/orchestrator" }
-provider = { package = "zombienet-provider", version = "0.2.4", path = "crates/provider" }
-prom-metrics-parser = { package = "zombienet-prom-metrics-parser", version = "0.2.4", path = "crates/prom-metrics-parser" }
-zombienet-sdk = { version = "0.2.4", path = "crates/sdk" }
+support = { package = "zombienet-support", version = "0.2.5", path = "crates/support" }
+configuration = { package = "zombienet-configuration", version = "0.2.5", path = "crates/configuration" }
+orchestrator = { package = "zombienet-orchestrator", version = "0.2.5", path = "crates/orchestrator" }
+provider = { package = "zombienet-provider", version = "0.2.5", path = "crates/provider" }
+prom-metrics-parser = { package = "zombienet-prom-metrics-parser", version = "0.2.5", path = "crates/prom-metrics-parser" }
+zombienet-sdk = { version = "0.2.5", path = "crates/sdk" }


### PR DESCRIPTION
Includes:
- wait methods for `metrics`
- wait methods for subxt client.