### PR TITLE
fix(chain-spec): adjust hrmp channels json structure

### DIFF
--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -921,9 +921,11 @@ fn add_authorities(
     nodes: &[&NodeSpec],
     use_stash: bool,
 ) {
-    let asset_hub_polkadot = chain_spec_json.get("id")
+    let asset_hub_polkadot = chain_spec_json
+        .get("id")
         .and_then(|v| v.as_str())
-        .map(|id| id.starts_with("asset-hub-polkadot")).unwrap_or_default();
+        .map(|id| id.starts_with("asset-hub-polkadot"))
+        .unwrap_or_default();
     if let Some(val) = chain_spec_json.pointer_mut(runtime_config_ptr) {
         let keys: Vec<GenesisNodeKey> = nodes
             .iter()
@@ -944,8 +946,14 @@ fn add_hrmp_channels(
             let hrmp_channels = hrmp_channels
                 .iter()
                 .map(|c| {
-                    (c.sender(), c.recipient(), c.max_capacity(), c.max_message_size())
-                }).collect::<Vec<_>>();
+                    (
+                        c.sender(),
+                        c.recipient(),
+                        c.max_capacity(),
+                        c.max_message_size(),
+                    )
+                })
+                .collect::<Vec<_>>();
             *preopen_hrmp_channels = json!(hrmp_channels);
         } else {
             warn!("⚠️  'hrmp/preopenHrmpChannels' key not present in runtime config.");
@@ -1243,9 +1251,13 @@ mod tests {
             ("aura".into(), sr.address.clone()),
             ("nimbus".into(), sr.address.clone()),
             ("vrf".into(), sr.address.clone()),
-            ("grandpa".into(), node.accounts.accounts["ed"].address.clone()),
+            (
+                "grandpa".into(),
+                node.accounts.accounts["ed"].address.clone(),
+            ),
             ("beefy".into(), node.accounts.accounts["ec"].address.clone()),
-        ].into();
+        ]
+        .into();
 
         // Stash
         let sr_stash = &node.accounts.accounts["sr_stash"];

--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -1186,8 +1186,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(new_hrmp_channels.len(), 2);
-        assert_eq!(new_hrmp_channels.first().unwrap()["sender"], 100);
-        assert_eq!(new_hrmp_channels.first().unwrap()["recipient"], 101);
+        assert_eq!(new_hrmp_channels.first().unwrap()[0], 100);
+        assert_eq!(new_hrmp_channels.first().unwrap()[1], 101);
+        assert_eq!(new_hrmp_channels.last().unwrap()[0], 101);
+        assert_eq!(new_hrmp_channels.last().unwrap()[1], 100);
     }
 
     #[test]

--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -934,6 +934,11 @@ fn add_hrmp_channels(
 ) {
     if let Some(val) = chain_spec_json.pointer_mut(runtime_config_ptr) {
         if let Some(preopen_hrmp_channels) = val.pointer_mut("/hrmp/preopenHrmpChannels") {
+            let hrmp_channels = hrmp_channels
+                .iter()
+                .map(|c| {
+                    (c.sender(), c.recipient(), c.max_capacity(), c.max_message_size())
+                }).collect::<Vec<_>>();
             *preopen_hrmp_channels = json!(hrmp_channels);
         } else {
             warn!("⚠️  'hrmp/preopenHrmpChannels' key not present in runtime config.");

--- a/crates/orchestrator/src/generators/keystore.rs
+++ b/crates/orchestrator/src/generators/keystore.rs
@@ -20,7 +20,7 @@ pub async fn generate<'a, T>(
     acc: &NodeAccounts,
     node_files_path: impl AsRef<Path>,
     scoped_fs: &ScopedFilesystem<'a, T>,
-    asset_hub_polkadot: bool
+    asset_hub_polkadot: bool,
 ) -> Result<Vec<PathBuf>, GeneratorError>
 where
     T: FileSystem,

--- a/crates/orchestrator/src/generators/keystore.rs
+++ b/crates/orchestrator/src/generators/keystore.rs
@@ -20,6 +20,7 @@ pub async fn generate<'a, T>(
     acc: &NodeAccounts,
     node_files_path: impl AsRef<Path>,
     scoped_fs: &ScopedFilesystem<'a, T>,
+    asset_hub_polkadot: bool
 ) -> Result<Vec<PathBuf>, GeneratorError>
 where
     T: FileSystem,
@@ -32,10 +33,15 @@ where
         // let filename = encode(k);
 
         let filename = match k {
-            // TODO: add logic for isAssetHubPolkadot
-            // "aura" => {
-            //     ""
-            // },
+            "aura" if asset_hub_polkadot => {
+                let pk = acc
+                    .accounts
+                    .get("ed")
+                    .expect(&format!("Key 'ed' should be set for node {THIS_IS_A_BUG}"))
+                    .public_key
+                    .as_str();
+                format!("{}{}", encode(k), pk)
+            },
             "babe" | "imon" | "audi" | "asgn" | "para" | "nmbs" | "rand" | "aura" => {
                 let pk = acc
                     .accounts

--- a/crates/orchestrator/src/spawner.rs
+++ b/crates/orchestrator/src/spawner.rs
@@ -61,8 +61,9 @@ where
         } else {
             node.name.clone()
         };
+        let asset_hub_polkadot = ctx.parachain_id.map(|id| id.starts_with("asset-hub-polkadot")).unwrap_or_default();
         let key_filenames =
-            generators::generate_node_keystore(&node.accounts, &node_files_path, ctx.scoped_fs)
+            generators::generate_node_keystore(&node.accounts, &node_files_path, ctx.scoped_fs, asset_hub_polkadot)
                 .await
                 .unwrap();
 

--- a/crates/orchestrator/src/spawner.rs
+++ b/crates/orchestrator/src/spawner.rs
@@ -61,11 +61,18 @@ where
         } else {
             node.name.clone()
         };
-        let asset_hub_polkadot = ctx.parachain_id.map(|id| id.starts_with("asset-hub-polkadot")).unwrap_or_default();
-        let key_filenames =
-            generators::generate_node_keystore(&node.accounts, &node_files_path, ctx.scoped_fs, asset_hub_polkadot)
-                .await
-                .unwrap();
+        let asset_hub_polkadot = ctx
+            .parachain_id
+            .map(|id| id.starts_with("asset-hub-polkadot"))
+            .unwrap_or_default();
+        let key_filenames = generators::generate_node_keystore(
+            &node.accounts,
+            &node_files_path,
+            ctx.scoped_fs,
+            asset_hub_polkadot,
+        )
+        .await
+        .unwrap();
 
         // Paths returned are relative to the base dir, we need to convert into
         // fullpaths to inject them in the nodes.


### PR DESCRIPTION
When testing `zombienet-sdk` with cross-chain calls with Asset Hub, we found that the hrmp channels passed to the chainspec caused the following issue:

`Error: "Invalid JSON blob: invalid type: map, expected a tuple of size 4 at line 1 column 2794"`

This is because the values of `HrmpChannelConfig` serialise to a map instead of a tuple, as expected by https://github.com/paritytech/polkadot-sdk/blob/fc906d5d0fb7796ef54ba670101cf37b0aad6794/polkadot/runtime/parachains/src/hrmp.rs#L492. Tests were updated accordingly to facilitate this fix.

Additional commits were also added to enable some of Asset Hub on Polkadot functionality observed in the classic Zombienet repo, so that we are able to launch a local Polkadot network with Asset Hub should anyone require. Example configuration files can be found at the bottom of https://github.com/r0gue-io/pop-cli/pull/278/files for anyone interested, although that PR is still a work in progress and dependent on this one being accepted.

PS - I added tests where I could, but additional tests might require some minor refactoring to make it easier to test only the logic that is changed by this PR, which I am not sure what the appetite is? An example would be refactoring the file name generation in `keystore.rs` into its own function to more easily test the outputs without the `scoped_fs`.

