### PR TITLE
add support for evm and fix stash account

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ tower = { version = "0.4" }
 tower-http = { version = "0.5" }
 tracing-subscriber = { version = "0.3" }
 glob-match = "0.2.1"
+libsecp256k1 = { version = "0.7.1", default-features = false }
 
 # Zombienet workspace crates:
 support = { package = "zombienet-support", version = "0.2.9", path = "crates/support" }

--- a/crates/configuration/src/parachain.rs
+++ b/crates/configuration/src/parachain.rs
@@ -18,7 +18,7 @@ use crate::{
             Arg, AssetLocation, Chain, ChainDefaultContext, Command, Image, ValidationContext, U128,
         },
     },
-    utils::{default_as_true, default_initial_balance, is_false},
+    utils::{default_as_false, default_as_true, default_initial_balance, is_false},
 };
 
 /// The registration strategy that will be used for the parachain.
@@ -136,6 +136,8 @@ pub struct ParachainConfig {
     chain_spec_command_is_local: bool,
     #[serde(rename = "cumulus_based", default = "default_as_true")]
     is_cumulus_based: bool,
+    #[serde(rename = "evm_based", default = "default_as_false")]
+    is_evm_based: bool,
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty", default)]
     bootnodes_addresses: Vec<Multiaddr>,
     genesis_overrides: Option<serde_json::Value>,
@@ -239,6 +241,11 @@ impl ParachainConfig {
         self.is_cumulus_based
     }
 
+    /// Whether the parachain is evm based (e.g frontier).
+    pub fn is_evm_based(&self) -> bool {
+        self.is_evm_based
+    }
+
     /// The bootnodes addresses the collators will connect to.
     pub fn bootnodes_addresses(&self) -> Vec<&Multiaddr> {
         self.bootnodes_addresses.iter().collect::<Vec<_>>()
@@ -302,6 +309,7 @@ impl<C: Context> Default for ParachainConfigBuilder<Initial, C> {
                 chain_spec_command: None,
                 chain_spec_command_is_local: false, // remote by default
                 is_cumulus_based: true,
+                is_evm_based: false,
                 bootnodes_addresses: vec![],
                 collators: vec![],
             },
@@ -707,6 +715,18 @@ impl<C: Context> ParachainConfigBuilder<WithId, C> {
         )
     }
 
+    /// Set whether the parachain is evm based (e.g frontier /evm template)
+    pub fn evm_based(self, choice: bool) -> Self {
+        Self::transition(
+            ParachainConfig {
+                is_evm_based: choice,
+                ..self.config
+            },
+            self.validation_context,
+            self.errors,
+        )
+    }
+
     /// Set the bootnodes addresses the collators will connect to.
     pub fn with_bootnodes_addresses<T>(self, bootnodes_addresses: Vec<T>) -> Self
     where
@@ -846,6 +866,7 @@ mod tests {
             .with_genesis_state_generator("generator_state")
             .with_chain_spec_path("./path/to/chain/spec.json")
             .cumulus_based(false)
+            .evm_based(false)
             .with_bootnodes_addresses(vec![
                 "/ip4/10.41.122.55/tcp/45421",
                 "/ip4/51.144.222.10/tcp/2333",
@@ -937,6 +958,7 @@ mod tests {
             parachain_config.bootnodes_addresses(),
             bootnodes_addresses.iter().collect::<Vec<_>>()
         );
+        assert!(!parachain_config.is_evm_based());
     }
 
     #[test]
@@ -1245,6 +1267,31 @@ mod tests {
             .unwrap();
 
         assert!(config.onboard_as_parachain());
+    }
+
+    #[test]
+    fn evm_based_default_to_false() {
+        let config = ParachainConfigBuilder::new(Default::default())
+            .with_id(2000)
+            .with_chain("myparachain")
+            .with_collator(|collator| collator.with_name("collator"))
+            .build()
+            .unwrap();
+
+        assert!(!config.is_evm_based());
+    }
+
+    #[test]
+    fn evm_based() {
+        let config = ParachainConfigBuilder::new(Default::default())
+            .with_id(2000)
+            .with_chain("myparachain")
+            .evm_based(true)
+            .with_collator(|collator| collator.with_name("collator"))
+            .build()
+            .unwrap();
+
+        assert!(config.is_evm_based());
     }
 
     #[test]

--- a/crates/configuration/src/parachain.rs
+++ b/crates/configuration/src/parachain.rs
@@ -1268,9 +1268,9 @@ mod tests {
         let parachain_evm = load_from_toml_small.parachains()[1];
 
         assert_eq!(parachain.registration_strategy(), None);
-        assert_eq!(parachain.is_evm_based(), false);
+        assert!(!parachain.is_evm_based());
         assert_eq!(parachain.collators().len(), 1);
-        assert_eq!(parachain_evm.is_evm_based(), true);
+        assert!(parachain_evm.is_evm_based());
     }
 
     #[test]

--- a/crates/configuration/src/parachain.rs
+++ b/crates/configuration/src/parachain.rs
@@ -1253,8 +1253,11 @@ mod tests {
         .unwrap();
 
         let parachain = load_from_toml_small.parachains()[0];
+        let parachain_evm = load_from_toml_small.parachains()[1];
 
         assert_eq!(parachain.registration_strategy(), None);
+        assert_eq!(parachain.is_evm_based(), false);
+        assert_eq!(parachain_evm.is_evm_based(), true);
     }
 
     #[test]

--- a/crates/configuration/src/utils.rs
+++ b/crates/configuration/src/utils.rs
@@ -12,6 +12,10 @@ pub(crate) fn default_as_true() -> bool {
     true
 }
 
+pub(crate) fn default_as_false() -> bool {
+    false
+}
+
 pub(crate) fn default_initial_balance() -> crate::types::U128 {
     2_000_000_000_000.into()
 }

--- a/crates/configuration/testing/snapshots/0001-big-network.toml
+++ b/crates/configuration/testing/snapshots/0001-big-network.toml
@@ -38,6 +38,7 @@ balance = 2000000000000
 default_db_snapshot = "https://storage.com/path/to/db_snapshot.tgz"
 chain_spec_path = "/path/to/my/chain/spec.json"
 cumulus_based = true
+evm_based = false
 
 [[parachains.collators]]
 name = "john"

--- a/crates/configuration/testing/snapshots/0001-big-network.toml
+++ b/crates/configuration/testing/snapshots/0001-big-network.toml
@@ -67,6 +67,7 @@ add_to_genesis = true
 balance = 2000000000000
 chain_spec_path = "/path/to/my/other/chain/spec.json"
 cumulus_based = true
+evm_based = false
 
 [[parachains.collators]]
 name = "mike"

--- a/crates/configuration/testing/snapshots/0002-overridden-defaults.toml
+++ b/crates/configuration/testing/snapshots/0002-overridden-defaults.toml
@@ -56,6 +56,7 @@ default_image = "mydefaultimage:latest"
 default_db_snapshot = "https://storage.com/path/to/other_snapshot.tgz"
 chain_spec_path = "/path/to/my/chain/spec.json"
 cumulus_based = true
+evm_based = false
 
 [[parachains.collators]]
 name = "john"

--- a/crates/configuration/testing/snapshots/0003-small-network_w_parachain.toml
+++ b/crates/configuration/testing/snapshots/0003-small-network_w_parachain.toml
@@ -38,3 +38,20 @@ validator = true
 invulnerable = true
 bootnode = true
 balance = 5000000000
+
+[[parachains]]
+id = 1000
+chain = "myparachain"
+onboard_as_parachain = false
+balance = 2000000000000
+default_db_snapshot = "https://storage.com/path/to/db_snapshot.tgz"
+chain_spec_path = "/path/to/my/chain/spec.json"
+cumulus_based = true
+evm_based = true
+
+[[parachains.collators]]
+name = "john"
+validator = true
+invulnerable = true
+bootnode = true
+balance = 5000000000

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -34,6 +34,7 @@ regex = { workspace = true }
 glob-match = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+libsecp256k1 = { workspace = true  }
 
 # Zombienet deps
 configuration = { workspace = true }

--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -449,7 +449,7 @@ impl ChainSpec {
 
             clear_authorities(&pointer, &mut chain_spec_json);
 
-            let key_type_to_use =  if para.is_evm_based {
+            let key_type_to_use = if para.is_evm_based {
                 SessionKeyType::Evm
             } else {
                 SessionKeyType::Default
@@ -467,12 +467,7 @@ impl ChainSpec {
                 .pointer(&format!("{}/session", pointer))
                 .is_some()
             {
-                add_authorities(
-                    &pointer,
-                    &mut chain_spec_json,
-                    &validators,
-                    key_type_to_use,
-                );
+                add_authorities(&pointer, &mut chain_spec_json, &validators, key_type_to_use);
             } else if chain_spec_json
                 .pointer(&format!("{}/aura", pointer))
                 .is_some()
@@ -490,7 +485,12 @@ impl ChainSpec {
                 .filter(|node| node.is_invulnerable)
                 .collect();
 
-            add_collator_selection(&pointer, &mut chain_spec_json, &invulnerables, key_type_to_use);
+            add_collator_selection(
+                &pointer,
+                &mut chain_spec_json,
+                &invulnerables,
+                key_type_to_use,
+            );
 
             // override `parachainInfo/parachainId`
             override_parachain_info(&pointer, &mut chain_spec_json, para.id);
@@ -1053,7 +1053,7 @@ fn add_collator_selection(
     session_key: SessionKeyType,
 ) {
     if let Some(val) = chain_spec_json.pointer_mut(runtime_config_ptr) {
-        let key_type = if let SessionKeyType::Evm = session_key  {
+        let key_type = if let SessionKeyType::Evm = session_key {
             "eth"
         } else {
             "sr"

--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -1053,7 +1053,7 @@ fn add_collator_selection(
     session_key: SessionKeyType,
 ) {
     if let Some(val) = chain_spec_json.pointer_mut(runtime_config_ptr) {
-        let key_type = if let sesssion_ky = SessionKeyType::Evm {
+        let key_type = if let sesssion_key = SessionKeyType::Evm {
             "eth"
         } else {
             "sr"

--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -1053,7 +1053,7 @@ fn add_collator_selection(
     session_key: SessionKeyType,
 ) {
     if let Some(val) = chain_spec_json.pointer_mut(runtime_config_ptr) {
-        let key_type = if let sesssion_key = SessionKeyType::Evm {
+        let key_type = if let SessionKeyType::Evm = session_key  {
             "eth"
         } else {
             "sr"

--- a/crates/orchestrator/src/network_spec.rs
+++ b/crates/orchestrator/src/network_spec.rs
@@ -285,7 +285,6 @@ impl NetworkSpec {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
 
     #[tokio::test]
     async fn small_network_config_get_spec() {

--- a/crates/orchestrator/src/network_spec.rs
+++ b/crates/orchestrator/src/network_spec.rs
@@ -285,6 +285,7 @@ impl NetworkSpec {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
 
     #[tokio::test]
     async fn small_network_config_get_spec() {

--- a/crates/orchestrator/src/network_spec/parachain.rs
+++ b/crates/orchestrator/src/network_spec/parachain.rs
@@ -55,6 +55,9 @@ pub struct ParachainSpec {
     /// Is the parachain cumulus-based
     pub(crate) is_cumulus_based: bool,
 
+    /// Is the parachain evm-based
+    pub(crate) is_evm_based: bool,
+
     /// Initial balance
     pub(crate) initial_balance: u128,
 
@@ -202,6 +205,7 @@ impl ParachainSpec {
                 .clone(),
             onboard_as_parachain: config.onboard_as_parachain(),
             is_cumulus_based: config.is_cumulus_based(),
+            is_evm_based: config.is_evm_based(),
             initial_balance: config.initial_balance(),
             genesis_state,
             genesis_wasm,


### PR DESCRIPTION
- Fix stash derivation (use `//`)
- Add `evm` support, you can set your parachain as evm based with `evm_based(choice: bool)`.


Fix: #247 
cc: @AlexD10S / @al3mart