### PR TITLE
bump version for release `0.2.10`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.2.9"
+version = "0.2.10"
 rust-version = "1.70.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/zombienet-sdk"
@@ -60,9 +60,9 @@ glob-match = "0.2.1"
 libsecp256k1 = { version = "0.7.1", default-features = false }
 
 # Zombienet workspace crates:
-support = { package = "zombienet-support", version = "0.2.9", path = "crates/support" }
-configuration = { package = "zombienet-configuration", version = "0.2.9", path = "crates/configuration" }
-orchestrator = { package = "zombienet-orchestrator", version = "0.2.9", path = "crates/orchestrator" }
-provider = { package = "zombienet-provider", version = "0.2.9", path = "crates/provider" }
-prom-metrics-parser = { package = "zombienet-prom-metrics-parser", version = "0.2.9", path = "crates/prom-metrics-parser" }
-zombienet-sdk = { version = "0.2.9", path = "crates/sdk" }
+support = { package = "zombienet-support", version = "0.2.10", path = "crates/support" }
+configuration = { package = "zombienet-configuration", version = "0.2.10", path = "crates/configuration" }
+orchestrator = { package = "zombienet-orchestrator", version = "0.2.10", path = "crates/orchestrator" }
+provider = { package = "zombienet-provider", version = "0.2.10", path = "crates/provider" }
+prom-metrics-parser = { package = "zombienet-prom-metrics-parser", version = "0.2.10", path = "crates/prom-metrics-parser" }
+zombienet-sdk = { version = "0.2.10", path = "crates/sdk" }


### PR DESCRIPTION
- Fixes: 
  - Use correct stash account
  -  Support single collator in `toml` (load from file)
  
- Added
  - Add support for `evm` parachains, through the `evm_based` config (both in load from toml and builder). 