### PR TITLE
bump versions for release `v0.2.11`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.2.10"
+version = "0.2.11"
 rust-version = "1.70.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/zombienet-sdk"
@@ -60,9 +60,9 @@ glob-match = "0.2.1"
 libsecp256k1 = { version = "0.7.1", default-features = false }
 
 # Zombienet workspace crates:
-support = { package = "zombienet-support", version = "0.2.10", path = "crates/support" }
-configuration = { package = "zombienet-configuration", version = "0.2.10", path = "crates/configuration" }
-orchestrator = { package = "zombienet-orchestrator", version = "0.2.10", path = "crates/orchestrator" }
-provider = { package = "zombienet-provider", version = "0.2.10", path = "crates/provider" }
-prom-metrics-parser = { package = "zombienet-prom-metrics-parser", version = "0.2.10", path = "crates/prom-metrics-parser" }
-zombienet-sdk = { version = "0.2.10", path = "crates/sdk" }
+support = { package = "zombienet-support", version = "0.2.11", path = "crates/support" }
+configuration = { package = "zombienet-configuration", version = "0.2.11", path = "crates/configuration" }
+orchestrator = { package = "zombienet-orchestrator", version = "0.2.11", path = "crates/orchestrator" }
+provider = { package = "zombienet-provider", version = "0.2.11", path = "crates/provider" }
+prom-metrics-parser = { package = "zombienet-prom-metrics-parser", version = "0.2.11", path = "crates/prom-metrics-parser" }
+zombienet-sdk = { version = "0.2.11", path = "crates/sdk" }


### PR DESCRIPTION
Added
 - Runtime upgrade helper for relaychain.