### PR TITLE
add validation to node name, can't be empty

### DIFF
--- a/crates/configuration/src/shared/errors.rs
+++ b/crates/configuration/src/shared/errors.rs
@@ -107,4 +107,7 @@ pub enum ValidationError {
 
     #[error("'{0}' is already used across config")]
     NodeNameAlreadyUsed(String),
+
+    #[error("can't be empty")]
+    CantBeEmpty(),
 }

--- a/crates/configuration/src/shared/helpers.rs
+++ b/crates/configuration/src/shared/helpers.rs
@@ -44,9 +44,7 @@ pub fn ensure_node_name_unique(
     Err(ValidationError::NodeNameAlreadyUsed(node_name).into())
 }
 
-pub fn ensure_value_is_not_empty(
-    value: &str,
-) -> Result<(), anyhow::Error> {
+pub fn ensure_value_is_not_empty(value: &str) -> Result<(), anyhow::Error> {
     if value.is_empty() {
         Err(ValidationError::CantBeEmpty().into())
     } else {

--- a/crates/configuration/src/shared/helpers.rs
+++ b/crates/configuration/src/shared/helpers.rs
@@ -28,19 +28,30 @@ pub fn merge_errors_vecs(
 }
 
 pub fn ensure_node_name_unique(
-    node_name: String,
+    node_name: impl Into<String>,
     validation_context: Rc<RefCell<ValidationContext>>,
 ) -> Result<(), anyhow::Error> {
     let mut context = validation_context
         .try_borrow_mut()
         .expect(&format!("{}, {}", BORROWABLE, THIS_IS_A_BUG));
 
+    let node_name = node_name.into();
     if !context.used_nodes_names.contains(&node_name) {
         context.used_nodes_names.push(node_name);
         return Ok(());
     }
 
     Err(ValidationError::NodeNameAlreadyUsed(node_name).into())
+}
+
+pub fn ensure_value_is_not_empty(
+    value: &str,
+) -> Result<(), anyhow::Error> {
+    if value.is_empty() {
+        Err(ValidationError::CantBeEmpty().into())
+    } else {
+        Ok(())
+    }
 }
 
 pub fn ensure_port_unique(

--- a/crates/configuration/src/shared/node.rs
+++ b/crates/configuration/src/shared/node.rs
@@ -5,7 +5,10 @@ use serde::{ser::SerializeStruct, Deserialize, Serialize};
 
 use super::{
     errors::FieldError,
-    helpers::{ensure_node_name_unique, ensure_port_unique, ensure_value_is_not_empty, merge_errors, merge_errors_vecs},
+    helpers::{
+        ensure_node_name_unique, ensure_port_unique, ensure_value_is_not_empty, merge_errors,
+        merge_errors_vecs,
+    },
     macros::states,
     resources::ResourcesBuilder,
     types::{AssetLocation, ChainDefaultContext, Command, Image, ValidationContext, U128},
@@ -340,10 +343,13 @@ impl NodeConfigBuilder<Initial> {
     pub fn with_name<T: Into<String> + Copy>(self, name: T) -> NodeConfigBuilder<Buildable> {
         let name: String = name.into();
 
-        match (ensure_value_is_not_empty(&name), ensure_node_name_unique(&name, self.validation_context.clone())) {
-            (Ok(_),Ok(_)) => Self::transition(
+        match (
+            ensure_value_is_not_empty(&name),
+            ensure_node_name_unique(&name, self.validation_context.clone()),
+        ) {
+            (Ok(_), Ok(_)) => Self::transition(
                 NodeConfig {
-                    name: name,
+                    name,
                     ..self.config
                 },
                 self.validation_context,
@@ -352,7 +358,7 @@ impl NodeConfigBuilder<Initial> {
             (Err(e), _) => Self::transition(
                 NodeConfig {
                     // we still set the name in error case to display error path
-                    name: name,
+                    name,
                     ..self.config
                 },
                 self.validation_context,
@@ -361,7 +367,7 @@ impl NodeConfigBuilder<Initial> {
             (_, Err(e)) => Self::transition(
                 NodeConfig {
                     // we still set the name in error case to display error path
-                    name: name,
+                    name,
                     ..self.config
                 },
                 self.validation_context,
@@ -1016,8 +1022,7 @@ mod tests {
     }
 
     #[test]
-    fn node_config_builder_should_fails_if_node_name_is_empty(
-    ) {
+    fn node_config_builder_should_fails_if_node_name_is_empty() {
         let validation_context = Rc::new(RefCell::new(ValidationContext {
             ..Default::default()
         }));
@@ -1029,9 +1034,6 @@ mod tests {
                 .unwrap_err();
 
         assert_eq!(errors.len(), 1);
-        assert_eq!(
-            errors.first().unwrap().to_string(),
-            "name: can't be empty"
-        );
+        assert_eq!(errors.first().unwrap().to_string(), "name: can't be empty");
     }
 }

--- a/crates/configuration/src/shared/node.rs
+++ b/crates/configuration/src/shared/node.rs
@@ -1014,4 +1014,24 @@ mod tests {
             "p2p_port: '45093' is already used across config"
         );
     }
+
+    #[test]
+    fn node_config_builder_should_fails_if_node_name_is_empty(
+    ) {
+        let validation_context = Rc::new(RefCell::new(ValidationContext {
+            ..Default::default()
+        }));
+
+        let (_, errors) =
+            NodeConfigBuilder::new(ChainDefaultContext::default(), validation_context)
+                .with_name("")
+                .build()
+                .unwrap_err();
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(
+            errors.first().unwrap().to_string(),
+            "name: can't be empty"
+        );
+    }
 }


### PR DESCRIPTION
Add: 
  - Validate `node_name`, can't be empty

cc: @ozgunozerk 