### PR TITLE
refactor exports from `sdk`

### DIFF
--- a/crates/file-server/src/main.rs
+++ b/crates/file-server/src/main.rs
@@ -45,7 +45,8 @@ async fn main() {
         .await
         .expect(&format!("failed to listen on {address}"));
     tracing::info!("file server started on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap()
+
+    axum::serve(listener, app).await.unwrap();
 }
 
 async fn upload(

--- a/crates/provider/src/docker/provider.rs
+++ b/crates/provider/src/docker/provider.rs
@@ -65,6 +65,7 @@ where
         provider
     }
 
+    /// Set tmp_dir to use as base for the provider
     pub fn tmp_dir(mut self, tmp_dir: impl Into<PathBuf>) -> Self {
         self.tmp_dir = tmp_dir.into();
         self

--- a/crates/provider/src/kubernetes/provider.rs
+++ b/crates/provider/src/kubernetes/provider.rs
@@ -49,6 +49,7 @@ where
         })
     }
 
+    /// Set tmp_dir to use as base for the provider
     pub fn tmp_dir(mut self, tmp_dir: impl Into<PathBuf>) -> Self {
         self.tmp_dir = tmp_dir.into();
         self

--- a/crates/provider/src/native/provider.rs
+++ b/crates/provider/src/native/provider.rs
@@ -49,6 +49,7 @@ where
         })
     }
 
+    /// Set tmp_dir to use as base for the provider
     pub fn tmp_dir(mut self, tmp_dir: impl Into<PathBuf>) -> Self {
         self.tmp_dir = tmp_dir.into();
         self

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1,26 +1,62 @@
 use async_trait::async_trait;
-pub use configuration::{NetworkConfig, NetworkConfigBuilder, RegistrationStrategy};
-#[cfg(feature = "pjs")]
-pub use orchestrator::pjs_helper::PjsResult;
+#[deprecated]
+pub use configuration::RegistrationStrategy;
+// Top level access to sdk
+pub use configuration::{NetworkConfig, NetworkConfigBuilder};
+// Orchestrator (TODO: export using orchestrator scope)
 pub use orchestrator::{
     errors::OrchestratorError,
     network::{node::NetworkNode, Network},
     AddCollatorOptions, AddNodeOptions, Orchestrator,
 };
 
-// Helpers used for interact with the network
-pub mod tx_helper {
-    pub use orchestrator::{
-        network::chain_upgrade::ChainUpgrade, shared::types::RuntimeUpgradeOptions,
+// Providers list
+pub const PROVIDERS: [&str; 3] = ["k8s", "native", "docker"];
+// Allow to create single provider from sdk
+pub mod provider {
+    pub use provider::{
+        DockerProvider, DynNamespace, DynNode, DynProvider, KubernetesProvider, NativeProvider,
     };
 }
 
-use provider::{DockerProvider, KubernetesProvider, NativeProvider};
+#[cfg(feature = "pjs")]
+pub use orchestrator::pjs_helper::PjsResult;
+
+// Helpers used for interact with the network
+pub mod tx_helper {
+    pub use orchestrator::{
+        // Runtime upgrade call
+        network::chain_upgrade::ChainUpgrade,
+        shared::types::RuntimeUpgradeOptions,
+    };
+}
+
+// Shared type from other crates
+pub mod shared {
+    pub mod configuration {
+        // Allow to construct config types
+        pub use configuration::shared::types::{Arg, AssetLocation};
+        pub use configuration::RegistrationStrategy; // TODO: move to shared
+    }
+
+    pub mod provider {
+        pub use provider::shared::types::{
+            ExecutionResult, RunCommandOptions, RunScriptOptions, SpawnNodeOptions,
+        };
+    }
+
+    pub mod support {
+        pub use support::net;
+    }
+}
+
+// LocalFileSystem used by orchestrator/provider
 pub use support::fs::local::LocalFileSystem;
 
+/// Environment helper
 pub mod environment;
-pub const PROVIDERS: [&str; 3] = ["k8s", "native", "docker"];
 
+use provider::{DockerProvider, KubernetesProvider, NativeProvider};
 #[async_trait]
 pub trait NetworkConfigExt {
     /// Spawns a network using the native or k8s provider.


### PR DESCRIPTION
Refactor some exports from `sdk` in order to build easily on top of the `sdk` directly.

From the `sdk` we expose now

```
/// Provider types to construct and work with it
provider::

/// Shared type from inner-crates
shared::
  configuration::
  provider::
  support::
```

cc: @ozgunozerk / @jmg-duarte