### PR TITLE
fix #274, refactor trait and make 'nodes' public again

### DIFF
--- a/crates/orchestrator/src/network/chain_upgrade.rs
+++ b/crates/orchestrator/src/network/chain_upgrade.rs
@@ -20,7 +20,11 @@ pub trait ChainUpgrade {
     ///
     /// This call 'System.set_code_without_checks' wrapped in
     /// 'Sudo.sudo_unchecked_weight'
-    async fn perform_runtime_upgrade(&self, node: &NetworkNode, options: RuntimeUpgradeOptions) -> Result<(), anyhow::Error> {
+    async fn perform_runtime_upgrade(
+        &self,
+        node: &NetworkNode,
+        options: RuntimeUpgradeOptions,
+    ) -> Result<(), anyhow::Error> {
         let sudo = if let Some(possible_seed) = options.seed {
             Keypair::from_secret_key(possible_seed)
                 .map_err(|_| anyhow!("seed should return a Keypair"))?

--- a/crates/orchestrator/src/network/parachain.rs
+++ b/crates/orchestrator/src/network/parachain.rs
@@ -3,8 +3,8 @@ use std::{
     str::FromStr,
 };
 
-use async_trait::async_trait;
 use anyhow::anyhow;
+use async_trait::async_trait;
 use provider::types::TransferedFile;
 use serde::Serialize;
 use subxt::{dynamic::Value, tx::TxStatus, OnlineClient, SubstrateConfig};
@@ -14,7 +14,8 @@ use tracing::info;
 
 use super::{chain_upgrade::ChainUpgrade, node::NetworkNode};
 use crate::{
-    network_spec::parachain::ParachainSpec, shared::types::{RegisterParachainOptions, RuntimeUpgradeOptions},
+    network_spec::parachain::ParachainSpec,
+    shared::types::{RegisterParachainOptions, RuntimeUpgradeOptions},
     ScopedFilesystem,
 };
 

--- a/crates/orchestrator/src/network/relaychain.rs
+++ b/crates/orchestrator/src/network/relaychain.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+
 use anyhow::anyhow;
 use async_trait::async_trait;
 use serde::Serialize;


### PR DESCRIPTION
fix #274 

refactor trait and fix `nodes()` visibility.

