### PR TITLE
Deprecate `client` function and replace with `try_client`

### DIFF
--- a/crates/examples/examples/add_para.rs
+++ b/crates/examples/examples/add_para.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let alice = network.get_node("alice")?;
     tokio::time::sleep(Duration::from_secs(10)).await;
     println!("{:#?}", alice);
-    let client = alice.client::<subxt::PolkadotConfig>().await?;
+    let client = alice.wait_client::<subxt::PolkadotConfig>().await?;
 
     // wait 3 blocks
     let mut blocks = client.blocks().subscribe_finalized().await?.take(3);

--- a/crates/examples/examples/para_upgrade.rs
+++ b/crates/examples/examples/para_upgrade.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // get current runtime spec
     let client = network
         .get_node("collator")?
-        .client::<subxt::PolkadotConfig>()
+        .wait_client::<subxt::PolkadotConfig>()
         .await?;
     let current_runtime = client.backend().current_runtime_version().await?;
     println!(

--- a/crates/examples/examples/pjs.rs
+++ b/crates/examples/examples/pjs.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("🚀🚀🚀🚀 network deployed");
 
     let alice = network.get_node("alice")?;
-    let client = alice.client::<subxt::PolkadotConfig>().await?;
+    let client = alice.wait_client::<subxt::PolkadotConfig>().await?;
 
     // wait 2 blocks
     let mut blocks = client.blocks().subscribe_finalized().await?.take(2);

--- a/crates/examples/examples/simple_network_example.rs
+++ b/crates/examples/examples/simple_network_example.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let client = network
         .get_node("collator01")?
-        .client::<subxt::PolkadotConfig>()
+        .wait_client::<subxt::PolkadotConfig>()
         .await?;
     let mut blocks = client.blocks().subscribe_finalized().await?.take(3);
 

--- a/crates/orchestrator/src/network/node.rs
+++ b/crates/orchestrator/src/network/node.rs
@@ -91,7 +91,22 @@ impl NetworkNode {
     }
 
     /// Get the [online client](subxt::client::OnlineClient) for the node
+    #[deprecated = "Use `wait_client` instead."]
     pub async fn client<Config: subxt::Config>(
+        &self,
+    ) -> Result<OnlineClient<Config>, subxt::Error> {
+        self.try_client().await
+    }
+
+    /// Try to connect to the node.
+    ///
+    /// Most of the time you only want to use [`wait_client`] that waits for
+    /// the node to appear before it connects to it. This function directly tries
+    /// to connect to the node and returns an error if the node is not yet available
+    /// at that point in time.
+    ///
+    /// Returns a [`OnlineClient`] on success.
+    pub async fn try_client<Config: subxt::Config>(
         &self,
     ) -> Result<OnlineClient<Config>, subxt::Error> {
         if subxt::utils::url_is_secure(&self.ws_uri)? {
@@ -109,7 +124,7 @@ impl NetworkNode {
             .await
             .map_err(|e| anyhow!("Error awaiting http_client to ws be ready, err: {}", e))?;
 
-        self.client()
+        self.try_client()
             .await
             .map_err(|e| anyhow!("Can't create a subxt client, err: {}", e))
     }

--- a/crates/orchestrator/src/network/node.rs
+++ b/crates/orchestrator/src/network/node.rs
@@ -100,7 +100,7 @@ impl NetworkNode {
 
     /// Try to connect to the node.
     ///
-    /// Most of the time you only want to use [`wait_client`] that waits for
+    /// Most of the time you only want to use [`NetworkNode::wait_client`] that waits for
     /// the node to appear before it connects to it. This function directly tries
     /// to connect to the node and returns an error if the node is not yet available
     /// at that point in time.
@@ -197,7 +197,7 @@ impl NetworkNode {
     }
 
     /// Assert on a metric value using a given predicate.
-    /// See [`reports`] description for details on metric name.
+    /// See [`NetworkNode::reports`] description for details on metric name.
     pub async fn assert_with(
         &self,
         metric_name: impl Into<String>,

--- a/crates/orchestrator/src/tx_helper/runtime_upgrade.rs
+++ b/crates/orchestrator/src/tx_helper/runtime_upgrade.rs
@@ -13,7 +13,7 @@ pub async fn upgrade(
         "Upgrading runtime, using node: {} with endpoting {}",
         node.name, node.ws_uri
     );
-    let api: OnlineClient<SubstrateConfig> = node.client().await?;
+    let api: OnlineClient<SubstrateConfig> = node.wait_client().await?;
 
     let upgrade = subxt::dynamic::tx(
         "System",

--- a/crates/sdk/tests/smoke.rs
+++ b/crates/sdk/tests/smoke.rs
@@ -127,7 +127,7 @@ async fn ci_k8s_basic_functionalities_should_works() {
 
     // collator
     let collator = network.get_node("collator").unwrap();
-    let client = collator.client::<subxt::PolkadotConfig>().await.unwrap();
+    let client = collator.wait_client::<subxt::PolkadotConfig>().await.unwrap();
 
     // wait 3 blocks
     let mut blocks = client.blocks().subscribe_finalized().await.unwrap().take(3);

--- a/crates/sdk/tests/smoke.rs
+++ b/crates/sdk/tests/smoke.rs
@@ -127,7 +127,10 @@ async fn ci_k8s_basic_functionalities_should_works() {
 
     // collator
     let collator = network.get_node("collator").unwrap();
-    let client = collator.wait_client::<subxt::PolkadotConfig>().await.unwrap();
+    let client = collator
+        .wait_client::<subxt::PolkadotConfig>()
+        .await
+        .unwrap();
 
     // wait 3 blocks
     let mut blocks = client.blocks().subscribe_finalized().await.unwrap().take(3);


### PR DESCRIPTION
Generally the idea is that `wait_client` should be used as a node can take a moment to appear online.