### PR TITLE
fix: override genesis to work with toml files/api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,8 @@ jobs:
           shared-key: "zombie-cache"
 
       - name: Clippy
-        run: cargo clippy --all-targets --all-features
+        # disable needless_lifetimes until we align the version with polakdot-sdk
+        run: cargo clippy --all-targets --all-features -- -A clippy::needless_lifetimes
 
       - name: Build
         run: cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,9 @@ pest_derive = "2.7"
 rand = "0.8"
 sha2 = { version = "0.10.2", default-features = false }
 hex = "0.4"
-sp-core = "34.0.0"
+sp-core = "35.0.0"
 libp2p = { version = "0.54.1" }
-subxt = { version = "0.38", features = ["substrate-compat"] }
+subxt = { version = "0.38" }
 subxt-signer = { version = "0.38", features = ["subxt"] }
 tracing = "0.1.35"
 kube = "0.87.1"

--- a/crates/configuration/Cargo.toml
+++ b/crates/configuration/Cargo.toml
@@ -22,6 +22,7 @@ toml = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
+tracing = { workspace = true }
 
 # zombienet deps
 support = { workspace = true }

--- a/crates/configuration/src/network.rs
+++ b/crates/configuration/src/network.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use support::constants::{
     NO_ERR_DEF_BUILDER, RELAY_NOT_NONE, RW_FAILED, THIS_IS_A_BUG, VALIDATION_CHECK, VALID_REGEX,
 };
+use tracing::trace;
 
 use crate::{
     global_settings::{GlobalSettings, GlobalSettingsBuilder},
@@ -72,10 +73,10 @@ impl NetworkConfig {
         let re: Regex = Regex::new(r"(?<field_name>(initial_)?balance)\s+=\s+(?<u128_value>\d+)")
             .expect(&format!("{} {}", VALID_REGEX, THIS_IS_A_BUG));
 
-        let mut network_config: NetworkConfig = toml::from_str(
-            re.replace_all(&file_str, "$field_name = \"$u128_value\"")
-                .as_ref(),
-        )?;
+        let toml_text = re.replace_all(&file_str, "$field_name = \"$u128_value\"");
+        trace!("toml text to parse: {}", toml_text);
+        let mut network_config: NetworkConfig = toml::from_str(&toml_text)?;
+        trace!("parsed config {network_config:#?}");
 
         // All unwraps below are safe, because we ensure that the relaychain is not None at this point
         if network_config.relaychain.is_none() {

--- a/crates/configuration/src/parachain.rs
+++ b/crates/configuration/src/parachain.rs
@@ -140,6 +140,7 @@ pub struct ParachainConfig {
     is_evm_based: bool,
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty", default)]
     bootnodes_addresses: Vec<Multiaddr>,
+    #[serde(rename = "genesis", skip_serializing_if = "Option::is_none")]
     genesis_overrides: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty", default)]
     pub(crate) collators: Vec<NodeConfig>,

--- a/crates/configuration/src/relaychain.rs
+++ b/crates/configuration/src/relaychain.rs
@@ -39,6 +39,7 @@ pub struct RelaychainConfig {
     max_nominations: Option<u8>,
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty", default)]
     nodes: Vec<NodeConfig>,
+    #[serde(rename = "genesis", skip_serializing_if = "Option::is_none")]
     runtime_genesis_patch: Option<serde_json::Value>,
     command: Option<Command>,
 }

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -42,5 +42,8 @@ support = { workspace = true }
 provider = { workspace = true }
 prom-metrics-parser = { workspace = true }
 
+[dev-dependencies]
+toml = { workspace = true }
+
 [features]
 pjs = ["dep:pjs-rs"]

--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -830,7 +830,7 @@ fn percolate_overrides<'a>(
     };
 
     let p = if i == pointer_parts.len() - 1 {
-        // top level key is at last part of the pointer
+        // top level key is at end of the pointer
         let p = format!("/{}", pointer_parts[i]);
         trace!("overrides pointer {p}");
         p

--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -442,8 +442,10 @@ impl ChainSpec {
 
             // make genesis overrides first.
             if let Some(overrides) = &para.genesis_overrides {
+                let percolated_overrides = percolate_overrides(&pointer, overrides)
+                    .map_err(|e| GeneratorError::ChainSpecGeneration(e.to_string()))?;
                 if let Some(genesis) = chain_spec_json.pointer_mut(&pointer) {
-                    merge(genesis, overrides);
+                    merge(genesis, percolated_overrides);
                 }
             }
 
@@ -541,8 +543,10 @@ impl ChainSpec {
 
             // make genesis overrides first.
             if let Some(overrides) = &relaychain.runtime_genesis_patch {
+                let percolated_overrides = percolate_overrides(&pointer, overrides)
+                    .map_err(|e| GeneratorError::ChainSpecGeneration(e.to_string()))?;
                 if let Some(patch_section) = chain_spec_json.pointer_mut(&pointer) {
-                    merge(patch_section, overrides);
+                    merge(patch_section, percolated_overrides);
                 }
             }
 
@@ -803,6 +807,77 @@ fn get_runtime_config_pointer(chain_spec_json: &serde_json::Value) -> Result<Str
     Err("Can not find the runtime pointer".into())
 }
 
+fn percolate_overrides<'a>(
+    pointer: &str,
+    overrides: &'a serde_json::Value,
+) -> Result<&'a serde_json::Value, anyhow::Error> {
+    let pointer_parts = pointer.split('/').collect::<Vec<&str>>();
+    trace!("pointer_parts: {pointer_parts:?}");
+
+    let top_level = overrides
+        .as_object()
+        .ok_or_else(|| anyhow!("Overrides must be an object"))?;
+    let top_level_key = top_level
+        .keys()
+        .next()
+        .ok_or_else(|| anyhow!("Invalid override value: {:?}", overrides))?;
+    trace!("top_level_key: {top_level_key}");
+    let index = pointer_parts.iter().position(|x| *x == top_level_key);
+    let Some(i) = index else {
+        return Err(anyhow!(
+            "Top level key {top_level_key} should be in the pointer: {pointer}"
+        ));
+    };
+
+    let p = if i == pointer_parts.len() - 1 {
+        // top level key is at last part of the pointer
+        let p = format!("/{}", pointer_parts[i]);
+        trace!("overrides pointer {p}");
+        p
+    } else {
+        // example: pointer is `/genesis/runtimeGenesis/patch` and the overrides start at  `runtimeGenesis`
+        let p = format!("/{}", pointer_parts[i..].join("/"));
+        trace!("overrides pointer {p}");
+        p
+    };
+    let overrides_to_use = overrides
+        .pointer(&p)
+        .ok_or_else(|| anyhow!("Invalid override value: {:?}", overrides))?;
+    Ok(overrides_to_use)
+}
+
+#[allow(dead_code)]
+fn construct_runtime_pointer_from_overrides(
+    overrides: &serde_json::Value,
+) -> Result<String, anyhow::Error> {
+    if overrides.get("genesis").is_some() {
+        // overrides already start with /genesis
+        return Ok("/genesis".into());
+    } else {
+        // check if we are one level inner
+        if let Some(top_level) = overrides.as_object() {
+            let k = top_level
+                .keys()
+                .next()
+                .ok_or_else(|| anyhow!("Invalid override value: {:?}", overrides))?;
+            match k.as_str() {
+                "runtimeGenesisConfigPatch" | "runtime" | "runtimeGenesis" => {
+                    return Ok(("/genesis").into())
+                },
+                "config" | "path" => {
+                    return Ok(("/genesis/runtimeGenesis").into());
+                },
+                "runtime_genesis_config" => {
+                    return Ok(("/genesis/runtime").into());
+                },
+                _ => {},
+            }
+        }
+    }
+
+    Err(anyhow!("Can not find the runtime pointer"))
+}
+
 // Merge `patch_section` with `overrides`.
 fn merge(patch_section: &mut serde_json::Value, overrides: &serde_json::Value) {
     trace!("patch: {:?}", patch_section);
@@ -830,6 +905,16 @@ fn merge(patch_section: &mut serde_json::Value, overrides: &serde_json::Value) {
                         trace!("not match!");
                     },
                 }
+            } else {
+                // Allow to add keys, see (https://github.com/paritytech/zombienet/issues/1614)
+                warn!(
+                    "key: {overrides_key} not present in genesis_obj: {:?} (adding key)",
+                    genesis_obj
+                );
+                let overrides_value = overrides_obj.get(overrides_key).expect(&format!(
+                    "overrides_key {overrides_key} should be present in the overrides obj. qed"
+                ));
+                genesis_obj.insert(overrides_key.clone(), overrides_value.clone());
             }
         }
     }
@@ -1156,6 +1241,42 @@ mod tests {
     fn chain_spec_test(file: &str) -> serde_json::Value {
         let content = fs::read_to_string(file).unwrap();
         serde_json::from_str(&content).unwrap()
+    }
+
+    #[test]
+    fn overrides_from_toml_works() {
+        use serde::{Deserialize, Serialize};
+
+        #[derive(Debug, Serialize, Deserialize)]
+        struct MockConfig {
+            #[serde(rename = "genesis", skip_serializing_if = "Option::is_none")]
+            genesis_overrides: Option<serde_json::Value>,
+        }
+
+        let mut chain_spec_json = chain_spec_test(ROCOCO_LOCAL_PLAIN_TESTING);
+        // Could also be  something like [genesis.runtimeGenesis.patch.balances]
+        const TOML: &str = "[genesis.runtime.balances]
+            devAccounts = [
+            20000,
+            1000000000000000000,
+            \"//Sender//{}\"
+        ]";
+        let override_toml: MockConfig = toml::from_str(TOML).unwrap();
+        let overrides = override_toml.genesis_overrides.unwrap();
+        let pointer = get_runtime_config_pointer(&chain_spec_json).unwrap();
+
+        let percolated_overrides = percolate_overrides(&pointer, &overrides)
+            .map_err(|e| GeneratorError::ChainSpecGeneration(e.to_string()))
+            .unwrap();
+        println!("percolated_overrides: {:#?}", percolated_overrides);
+        if let Some(genesis) = chain_spec_json.pointer_mut(&pointer) {
+            merge(genesis, percolated_overrides);
+        }
+
+        println!("chain spec: {chain_spec_json:#?}");
+        assert!(chain_spec_json
+            .pointer("/genesis/runtime/balances/devAccounts")
+            .is_some());
     }
 
     #[test]

--- a/crates/orchestrator/src/network/node.rs
+++ b/crates/orchestrator/src/network/node.rs
@@ -190,13 +190,14 @@ impl NetworkNode {
     ) -> Result<bool, anyhow::Error> {
         let metric_name = metric_name.into();
         let val = self.metric(&metric_name, true).await?;
+        trace!("🔎 Current value {val} passed to the predicated? (from cache)");
         if predicate(val) {
             Ok(true)
         } else {
             // reload metrics
             self.fetch_metrics().await?;
             let val = self.metric(&metric_name, true).await?;
-            trace!("🔎 Current value passed to the predicated: {val}");
+            trace!("🔎 Current value {val} passed to the predicated?");
             Ok(predicate(val))
         }
     }
@@ -282,7 +283,7 @@ impl NetworkNode {
     }
 
     /// Wait until a the number of matching log lines is reach
-    pub async fn wait_log_line_count<'a>(
+    pub async fn wait_log_line_count(
         &self,
         pattern: impl Into<String>,
         is_glob: bool,

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -17,7 +17,7 @@ async-trait = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
 lazy_static = { workspace = true }
-subxt = { workspace = true, features = ["substrate-compat"] }
+subxt = { workspace = true }
 subxt-signer = { workspace = true, features = ["subxt"] }
 
 # Zombienet deps


### PR DESCRIPTION
Add logic to allow overrides working with network definition in `toml` format and sdk api.

cc: @iulianbarbu 
