### PR TITLE
fix(#280) Add 'CommandWithCustomArgs' to allow use custom args to generate the …

### DIFF
--- a/crates/configuration/src/parachain.rs
+++ b/crates/configuration/src/parachain.rs
@@ -18,6 +18,7 @@ use crate::{
             Arg, AssetLocation, Chain, ChainDefaultContext, Command, Image, ValidationContext, U128,
         },
     },
+    types::CommandWithCustomArgs,
     utils::{default_as_false, default_as_true, default_initial_balance, is_false},
 };
 
@@ -125,7 +126,7 @@ pub struct ParachainConfig {
     genesis_wasm_path: Option<AssetLocation>,
     genesis_wasm_generator: Option<Command>,
     genesis_state_path: Option<AssetLocation>,
-    genesis_state_generator: Option<Command>,
+    genesis_state_generator: Option<CommandWithCustomArgs>,
     chain_spec_path: Option<AssetLocation>,
     // Full _template_ command, will be rendered using [tera]
     // and executed for generate the chain-spec.
@@ -220,7 +221,7 @@ impl ParachainConfig {
     }
 
     /// The generator command used to create the genesis state of the parachain.
-    pub fn genesis_state_generator(&self) -> Option<&Command> {
+    pub fn genesis_state_generator(&self) -> Option<&CommandWithCustomArgs> {
         self.genesis_state_generator.as_ref()
     }
 
@@ -645,7 +646,7 @@ impl<C: Context> ParachainConfigBuilder<WithId, C> {
     /// Set the generator command used to create the genesis state of the parachain.
     pub fn with_genesis_state_generator<T>(self, command: T) -> Self
     where
-        T: TryInto<Command>,
+        T: TryInto<CommandWithCustomArgs>,
         T::Error: Error + Send + Sync + 'static,
     {
         match command.try_into() {
@@ -955,7 +956,11 @@ mod tests {
             AssetLocation::FilePath(value) if value.to_str().unwrap() == "./path/to/genesis/state"
         ));
         assert_eq!(
-            parachain_config.genesis_state_generator().unwrap().as_str(),
+            parachain_config
+                .genesis_state_generator()
+                .unwrap()
+                .cmd()
+                .as_str(),
             "generator_state"
         );
         assert!(matches!(

--- a/crates/configuration/src/shared/errors.rs
+++ b/crates/configuration/src/shared/errors.rs
@@ -97,6 +97,9 @@ pub enum ConversionError {
 
     #[error("can't be empty")]
     CantBeEmpty,
+
+    #[error("deserialize error")]
+    DeserializeError(String),
 }
 
 /// A validation error for shared types across fields.

--- a/crates/configuration/src/shared/types.rs
+++ b/crates/configuration/src/shared/types.rs
@@ -249,11 +249,6 @@ impl Default for CommandWithCustomArgs {
 
 impl CommandWithCustomArgs {
     pub fn cmd(&self) -> &Command {
-        // let args = self.1.iter().map(|x| x.into()).collect::<Vec<String>>();
-        // (&self.0.as_str(), &self.1)
-        // let a = &self.1[0];
-        // let b: &str = a
-        // (&self.0,&self.1)
         &self.0
     }
 

--- a/crates/orchestrator/src/network_spec/parachain.rs
+++ b/crates/orchestrator/src/network_spec/parachain.rs
@@ -162,7 +162,7 @@ impl ParachainSpec {
             )
         } else {
             let cmd = if let Some(cmd) = config.genesis_state_generator() {
-                cmd
+                cmd.cmd()
             } else {
                 main_cmd
             };
@@ -180,13 +180,13 @@ impl ParachainSpec {
             )
         } else {
             let cmd = if let Some(cmd) = config.genesis_wasm_generator() {
-                cmd
+                cmd.as_str()
             } else {
-                main_cmd
+                main_cmd.as_str()
             };
             ParaArtifact::new(
                 ParaArtifactType::Wasm,
-                ParaArtifactBuildOption::Command(cmd.as_str().into()),
+                ParaArtifactBuildOption::Command(cmd.into()),
             )
             .image(main_image.clone())
         };


### PR DESCRIPTION
…para state

Fix #280 

Add a new type `CommandWithCustomArgs` that allow to pass a cmd and custom args (e.g `undying-collator export-genesis-state --pov-size={{25000*(id-1999)}} --pvf-complexity=1`) to be used to generate the genesis state for a parachain.

cc: @alindima 