### PR TITLE
fix: #254, allow toml without 'settings' (set defaults)

### DIFF
--- a/crates/configuration/src/global_settings.rs
+++ b/crates/configuration/src/global_settings.rs
@@ -15,7 +15,7 @@ use crate::{
         helpers::{merge_errors, merge_errors_vecs},
         types::Duration,
     },
-    utils::default_node_spawn_timeout,
+    utils::{default_node_spawn_timeout, default_timeout},
 };
 
 /// Global settings applied to an entire network.
@@ -26,7 +26,7 @@ pub struct GlobalSettings {
     bootnodes_addresses: Vec<Multiaddr>,
     // TODO: parse both case in zombienet node version to avoid renamed ?
     /// Global spawn timeout
-    #[serde(rename = "timeout")]
+    #[serde(rename = "timeout", default = "default_timeout")]
     network_spawn_timeout: Duration,
     // TODO: not used yet
     /// Node spawn timeout
@@ -69,6 +69,18 @@ impl GlobalSettings {
     }
 }
 
+impl Default for GlobalSettings {
+    fn default() -> Self {
+        Self {
+            bootnodes_addresses: Default::default(),
+            network_spawn_timeout: default_timeout(),
+            node_spawn_timeout: default_node_spawn_timeout(),
+            local_ip: Default::default(),
+            base_dir: Default::default(),
+        }
+    }
+}
+
 /// A global settings builder, used to build [`GlobalSettings`] declaratively with fields validation.
 pub struct GlobalSettingsBuilder {
     config: GlobalSettings,
@@ -80,8 +92,8 @@ impl Default for GlobalSettingsBuilder {
         Self {
             config: GlobalSettings {
                 bootnodes_addresses: vec![],
-                network_spawn_timeout: 1000,
-                node_spawn_timeout: 300,
+                network_spawn_timeout: default_timeout(),
+                node_spawn_timeout: default_node_spawn_timeout(),
                 local_ip: None,
                 base_dir: None,
             },

--- a/crates/configuration/src/network.rs
+++ b/crates/configuration/src/network.rs
@@ -25,7 +25,7 @@ use crate::{
 /// A network configuration, composed of a relaychain, parachains and HRMP channels.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NetworkConfig {
-    #[serde(rename = "settings")]
+    #[serde(rename = "settings", default = "GlobalSettings::default")]
     global_settings: GlobalSettings,
     relaychain: Option<RelaychainConfig>,
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty", default)]
@@ -1139,6 +1139,30 @@ mod tests {
                     loaded_node.initial_balance()
                 );
             });
+    }
+
+    #[test]
+    fn the_toml_config_without_settings_should_be_imported_and_match_a_network() {
+        let load_from_toml = NetworkConfig::load_from_toml(
+            "./testing/snapshots/0004-small-network-without-settings.toml",
+        )
+        .unwrap();
+
+        let expected = NetworkConfigBuilder::new()
+            .with_relaychain(|relaychain| {
+                relaychain
+                    .with_chain("rococo-local")
+                    .with_default_command("polkadot")
+                    .with_node(|node| node.with_name("alice"))
+                    .with_node(|node| node.with_name("bob"))
+            })
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            load_from_toml.global_settings().network_spawn_timeout(),
+            expected.global_settings().network_spawn_timeout()
+        )
     }
 
     #[test]

--- a/crates/configuration/src/utils.rs
+++ b/crates/configuration/src/utils.rs
@@ -20,8 +20,14 @@ pub(crate) fn default_initial_balance() -> crate::types::U128 {
     2_000_000_000_000.into()
 }
 
+/// Default timeout for spawning a node (5mins)
 pub(crate) fn default_node_spawn_timeout() -> Duration {
     300
+}
+
+/// Default timeout for spawning the whole network (1hr)
+pub(crate) fn default_timeout() -> Duration {
+    3600
 }
 
 pub(crate) fn default_command_polkadot() -> Option<Command> {

--- a/crates/configuration/testing/snapshots/0000-small-network.toml
+++ b/crates/configuration/testing/snapshots/0000-small-network.toml
@@ -1,5 +1,5 @@
 [settings]
-timeout = 1000
+timeout = 3600
 node_spawn_timeout = 300
 
 [relaychain]

--- a/crates/configuration/testing/snapshots/0001-big-network.toml
+++ b/crates/configuration/testing/snapshots/0001-big-network.toml
@@ -1,5 +1,5 @@
 [settings]
-timeout = 1000
+timeout = 3600
 node_spawn_timeout = 300
 
 [relaychain]

--- a/crates/configuration/testing/snapshots/0002-overridden-defaults.toml
+++ b/crates/configuration/testing/snapshots/0002-overridden-defaults.toml
@@ -1,5 +1,5 @@
 [settings]
-timeout = 1000
+timeout = 3600
 node_spawn_timeout = 300
 
 [relaychain]

--- a/crates/configuration/testing/snapshots/0003-small-network_w_parachain.toml
+++ b/crates/configuration/testing/snapshots/0003-small-network_w_parachain.toml
@@ -1,5 +1,5 @@
 [settings]
-timeout = 1000
+timeout = 3600
 node_spawn_timeout = 300
 
 [relaychain]

--- a/crates/configuration/testing/snapshots/0004-small-network-without-settings.toml
+++ b/crates/configuration/testing/snapshots/0004-small-network-without-settings.toml
@@ -1,0 +1,9 @@
+[relaychain]
+chain = "rococo-local"
+default_command = "polkadot"
+
+[[relaychain.nodes]]
+name = "alice"
+
+[[relaychain.nodes]]
+name = "bob"


### PR DESCRIPTION
Fix #254 

Add logic to load `toml`s without `[settings]` (set defaults).

cc: @jmg-duarte 