### PR TITLE
Upgrade pjs and reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,21 +44,21 @@ rand = "0.8"
 sha2 = { version = "0.10.2", default-features = false }
 hex = "0.4"
 sp-core = "35.0.0"
-libp2p = { version = "0.54.1" }
-subxt = { version = "0.38" }
+libp2p = "0.54.1"
+subxt = "0.38"
 subxt-signer = { version = "0.38", features = ["subxt"] }
 tracing = "0.1.35"
 kube = "0.87.1"
 k8s-openapi = "0.20.0"
 tar = "0.4"
-axum = { version = "0.7" }
-axum-extra = { version = "0.9" }
-tower = { version = "0.4" }
-tower-http = { version = "0.5" }
-tracing-subscriber = { version = "0.3" }
+axum = "0.7"
+axum-extra = "0.9"
+tower = "0.4"
+tower-http = "0.5"
+tracing-subscriber = "0.3"
 glob-match = "0.2.1"
 libsecp256k1 = { version = "0.7.1", default-features = false }
-pjs-rs = { version = "0.1.4" }
+pjs-rs = "0.1.4"
 flate2 = "1.0"
 
 # Zombienet workspace crates:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ tracing-subscriber = { version = "0.3" }
 glob-match = "0.2.1"
 libsecp256k1 = { version = "0.7.1", default-features = false }
 pjs-rs = { version = "0.1.4" }
+flate2 = "1.0"
 
 # Zombienet workspace crates:
 support = { package = "zombienet-support", version = "0.2.24", path = "crates/support" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ serde_yaml = "0.9"
 toml = "0.8.19"
 tokio = "1.28"
 tokio-util = "0.7"
-reqwest = "0.11"
+reqwest = "0.12.9"
 regex = "1.8"
 lazy_static = "1.4"
 multiaddr = "0.18"
@@ -58,6 +58,7 @@ tower-http = { version = "0.5" }
 tracing-subscriber = { version = "0.3" }
 glob-match = "0.2.1"
 libsecp256k1 = { version = "0.7.1", default-features = false }
+pjs-rs = { version = "0.1.4" }
 
 # Zombienet workspace crates:
 support = { package = "zombienet-support", version = "0.2.24", path = "crates/support" }

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2021"
 zombienet-sdk = {workspace = true, features = ["pjs"]}
 tokio = { workspace = true }
 futures = { workspace = true }
-tracing-subscriber = "0.3"
+tracing-subscriber = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -28,7 +28,7 @@ subxt = { workspace = true }
 subxt-signer = { workspace = true }
 reqwest = { workspace = true }
 tracing = { workspace = true }
-pjs-rs = { version = "0.1.2", optional = true }
+pjs-rs = { workspace = true, optional = true }
 uuid = { workspace = true }
 regex = { workspace = true }
 glob-match = { workspace = true }

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -39,7 +39,7 @@ tracing = { workspace = true }
 reqwest = { workspace = true }
 regex = { workspace = true }
 url = { workspace = true }
-flate2 = "1.0"
+flate2 = { workspace = true }
 
 # Zomebienet deps
 support = { workspace = true }

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -27,7 +27,7 @@ provider = { workspace = true }
 support = { workspace = true }
 
 [dev-dependencies]
-tracing-subscriber = "0.3"
+tracing-subscriber = { workspace = true }
 kube = { workspace = true, features = ["ws", "runtime"] }
 k8s-openapi = { workspace = true, features = ["v1_27"] }
 serde_json = {workspace = true }


### PR DESCRIPTION
Now, dependencies are aligned with polkadot-sdk, and Deno no longer blocks future dependency upgradation