### PR TITLE
add option to override `wasm` in chain-spec

### DIFF
--- a/crates/configuration/src/network.rs
+++ b/crates/configuration/src/network.rs
@@ -857,7 +857,6 @@ mod tests {
                     .with_default_command("polkadot")
                     .with_default_image("docker.io/parity/polkadot:latest")
                     .with_default_args(vec![("-lparachain", "debug").into()])
-                    .with_wasm_override("/some/path/runtime.wasm")
                     .with_node(|node| node.with_name("alice").validator(true))
                     .with_node(|node| {
                         node.with_name("bob")

--- a/crates/configuration/src/network.rs
+++ b/crates/configuration/src/network.rs
@@ -1671,8 +1671,8 @@ mod tests {
             })
             .with_parachain(|p| {
                 p.with_id(1000)
-                .with_wasm_override("https://some.com/runtime.wasm")
-                .with_collator(|c| c.with_name("john"))
+                    .with_wasm_override("https://some.com/runtime.wasm")
+                    .with_collator(|c| c.with_name("john"))
             })
             .build()
             .unwrap();

--- a/crates/configuration/src/network.rs
+++ b/crates/configuration/src/network.rs
@@ -857,6 +857,7 @@ mod tests {
                     .with_default_command("polkadot")
                     .with_default_image("docker.io/parity/polkadot:latest")
                     .with_default_args(vec![("-lparachain", "debug").into()])
+                    .with_wasm_override("/some/path/runtime.wasm")
                     .with_node(|node| node.with_name("alice").validator(true))
                     .with_node(|node| {
                         node.with_name("bob")
@@ -1649,6 +1650,40 @@ mod tests {
         assert_eq!(
             errors.first().unwrap().to_string(),
             "parachain[1].collators[''].name: can't be empty"
+        );
+    }
+
+    #[test]
+    fn wasm_override_in_toml_should_work() {
+        let load_from_toml = NetworkConfig::load_from_toml(
+            "./testing/snapshots/0005-small-networl-with-wasm-override.toml",
+        )
+        .unwrap();
+
+        let expected = NetworkConfigBuilder::new()
+            .with_relaychain(|relaychain| {
+                relaychain
+                    .with_chain("rococo-local")
+                    .with_default_command("polkadot")
+                    .with_wasm_override("/some/path/runtime.wasm")
+                    .with_node(|node| node.with_name("alice"))
+                    .with_node(|node| node.with_name("bob"))
+            })
+            .with_parachain(|p| {
+                p.with_id(1000)
+                .with_wasm_override("https://some.com/runtime.wasm")
+                .with_collator(|c| c.with_name("john"))
+            })
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            load_from_toml.relaychain().wasm_override(),
+            expected.relaychain().wasm_override()
+        );
+        assert_eq!(
+            load_from_toml.parachains()[0].wasm_override(),
+            expected.parachains()[0].wasm_override()
         );
     }
 }

--- a/crates/configuration/testing/snapshots/0005-small-networl-with-wasm-override.toml
+++ b/crates/configuration/testing/snapshots/0005-small-networl-with-wasm-override.toml
@@ -1,0 +1,17 @@
+[relaychain]
+chain = "rococo-local"
+default_command = "polkadot"
+wasm_override = "/some/path/runtime.wasm"
+
+[[relaychain.nodes]]
+name = "alice"
+
+[[relaychain.nodes]]
+name = "bob"
+
+[[parachains]]
+id = 1000
+wasm_override = "https://some.com/runtime.wasm"
+
+[parachains.collator]
+name = "john"

--- a/crates/orchestrator/src/generators/errors.rs
+++ b/crates/orchestrator/src/generators/errors.rs
@@ -17,4 +17,6 @@ pub enum GeneratorError {
     IdentityGeneration(String),
     #[error("Generating bootnode address, err {0}")]
     BootnodeAddrGeneration(String),
+    #[error("Error overriding wasm on raw chain-spec, err {0}")]
+    OverridingWasm(String),
 }

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -180,6 +180,15 @@ where
             .build_raw(&ns, &scoped_fs)
             .await?;
 
+        // override wasm if needed
+        if let Some(ref wasm_override) = network_spec.relaychain.wasm_override {
+            network_spec
+                .relaychain
+                .chain_spec
+                .override_code(&scoped_fs, wasm_override)
+                .await?;
+        }
+
         let (bootnodes, relaynodes) = split_nodes_by_bootnodes(&network_spec.relaychain.nodes);
 
         // TODO: we want to still supporting spawn a dedicated bootnode??

--- a/crates/orchestrator/src/network_spec/relaychain.rs
+++ b/crates/orchestrator/src/network_spec/relaychain.rs
@@ -50,6 +50,9 @@ pub struct RelaychainSpec {
     /// Genesis overrides as JSON value.
     pub(crate) runtime_genesis_patch: Option<serde_json::Value>,
 
+    /// Wasm override path/url to use.
+    pub(crate) wasm_override: Option<AssetLocation>,
+
     /// Nodes to run.
     pub(crate) nodes: Vec<NodeSpec>,
 }
@@ -128,6 +131,7 @@ impl RelaychainSpec {
             default_image: config.default_image().cloned(),
             default_resources: config.default_resources().cloned(),
             default_db_snapshot: config.default_db_snapshot().cloned(),
+            wasm_override: config.wasm_override().cloned(),
             default_args: config.default_args().into_iter().cloned().collect(),
             chain_spec,
             random_nominators_count: config.random_nominators_count().unwrap_or(0),


### PR DESCRIPTION
Add `with_wasm_override` fn to both `relaychain` and `parachain` builders.

cc: @ggwpez 