### PR TITLE
[CI] use our init image to get the bins

### DIFF
--- a/crates/provider/src/kubernetes/pod_spec_builder.rs
+++ b/crates/provider/src/kubernetes/pod_spec_builder.rs
@@ -73,7 +73,7 @@ impl PodSpecBuilder {
     fn build_helper_binaries_setup_container() -> Container {
         Container {
             name: "helper-binaries-setup".to_string(),
-            image: Some("docker.io/alpine:latest".to_string()),
+            image: Some("europe-west3-docker.pkg.dev/parity-zombienet/zombienet-public-images/alpine:latest".to_string()),
             image_pull_policy: Some("IfNotPresent".to_string()),
             volume_mounts: Some(Self::build_volume_mounts(vec![VolumeMount {
                 name: "helper-binaries-downloader-volume".to_string(),

--- a/crates/provider/src/shared/scripts/helper-binaries-downloader.sh
+++ b/crates/provider/src/shared/scripts/helper-binaries-downloader.sh
@@ -9,14 +9,26 @@ log() {
 # where some node files are stored
 OUTDIR=$([ -d /helpers ] && echo "/helpers" || echo "/cfg")
 
-wget github.com/moparisthebest/static-curl/releases/download/v7.83.1/curl-amd64 -O "$OUTDIR/curl"
-log "curl downloaded"
+# Allow to use our image and just cp'd the binaries.
+
+if [ -f /tmp/curl ]; then
+    cp /tmp/curl $OUTDIR/curl
+    log "curl copied"
+else
+    wget github.com/moparisthebest/static-curl/releases/download/v7.83.1/curl-amd64 -O "$OUTDIR/curl"
+    log "curl downloaded"
+fi;
 
 chmod +x "$OUTDIR/curl"
 log "curl chmoded"
 
-wget -qO- github.com/uutils/coreutils/releases/download/0.0.17/coreutils-0.0.17-x86_64-unknown-linux-musl.tar.gz | tar -xz -C $OUTDIR --strip-components=1 coreutils-0.0.17-x86_64-unknown-linux-musl/coreutils
-log "coreutils downloaded"
+if [ -f /tmp/coreutils ]; then
+    cp /tmp/coreutils $OUTDIR/coreutils
+    log "coreutils copied"
+else
+    wget -qO- github.com/uutils/coreutils/releases/download/0.0.17/coreutils-0.0.17-x86_64-unknown-linux-musl.tar.gz | tar -xz -C $OUTDIR --strip-components=1 coreutils-0.0.17-x86_64-unknown-linux-musl/coreutils
+    log "coreutils downloaded"
+fi;
 
 chmod +x "$OUTDIR/coreutils"
 log "coreutils chmoded"


### PR DESCRIPTION
Fix `ci` issues where we get error download bins from gh.