### PR TITLE
add logs with binaries path

### DIFF
--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -478,15 +478,25 @@ fn validate_spec_with_provider_capabilities(
         for cmd in cmds {
             let missing = if cmd.contains('/') {
                 trace!("checking {cmd}");
-                std::fs::metadata(cmd).is_err()
+                if std::fs::metadata(cmd).is_err() {
+                    true
+                } else {
+                    info!("🔎  We will use the full path {cmd} to spawn nodes.");
+                    false
+                }
             } else {
                 // should be in the PATH
                 !parts.iter().any(|part| {
                     let path_to = format!("{}/{}", part, cmd);
                     trace!("checking {path_to}");
-                    let check_result = std::fs::metadata(path_to);
+                    let check_result = std::fs::metadata(&path_to);
                     trace!("result {:?}", check_result);
-                    check_result.is_ok()
+                    if check_result.is_ok() {
+                        info!("🔎  We will use the cmd: '{cmd}' at path {path_to} to spawn nodes.");
+                        true
+                    } else {
+                        false
+                    }
                 })
             };
 


### PR DESCRIPTION
Add log to show binaries path:


example for cmd 
```
2025-03-16T17:22:50.037467Z  INFO zombienet_orchestrator: 🔎  We will use the cmd: 'polkadot' at path /Users/user1/parity/polkadot-sdk/target/release/polkadot to spawn nodes.
```
Example with cmd (absolute path)
```
2025-03-16T17:22:50.037753Z  INFO zombienet_orchestrator: 🔎  We will use the full path /Users/user1/parity/polkadot-sdk/target/release/polkadot-parachain to spawn nodes.
```

cc: @michalkucharczyk 

fix #306 