### PR TITLE
feat: add multi_addr support for NetworkNode

### DIFF
--- a/crates/orchestrator/src/network/node.rs
+++ b/crates/orchestrator/src/network/node.rs
@@ -32,6 +32,7 @@ pub struct NetworkNode {
     pub(crate) name: String,
     pub(crate) ws_uri: String,
     pub(crate) prometheus_uri: String,
+    pub(crate) multi_addr: String,
     #[serde(skip)]
     metrics_cache: Arc<RwLock<MetricMap>>,
 }
@@ -54,6 +55,7 @@ impl NetworkNode {
         name: T,
         ws_uri: T,
         prometheus_uri: T,
+        multi_addr: T,
         spec: NodeSpec,
         inner: DynNode,
     ) -> Self {
@@ -61,6 +63,7 @@ impl NetworkNode {
             name: name.into(),
             ws_uri: ws_uri.into(),
             prometheus_uri: prometheus_uri.into(),
+            multi_addr: multi_addr.into(),
             inner,
             spec,
             metrics_cache: Arc::new(Default::default()),
@@ -81,6 +84,10 @@ impl NetworkNode {
 
     pub fn ws_uri(&self) -> &str {
         &self.ws_uri
+    }
+
+    pub fn multi_addr(&self) -> &str {
+        &self.multi_addr
     }
 
     // Subxt

--- a/crates/orchestrator/src/spawner.rs
+++ b/crates/orchestrator/src/spawner.rs
@@ -243,6 +243,15 @@ where
         }
     }
 
+    // TODO: change generate_node_bootnode_addr name to more adequate
+    let multi_addr = generators::generate_node_bootnode_addr(
+        &node.peer_id,
+        &ip_to_use,
+        node.p2p_port.0,
+        running_node.args().as_ref(),
+        &node.p2p_cert_hash,
+    )?;
+
     let ws_uri = format!("ws://{}:{}", ip_to_use, rpc_port_external);
     let prometheus_uri = format!("http://{}:{}/metrics", ip_to_use, prometheus_port_external);
     info!("🚀 {}, should be running now", node.name);
@@ -270,6 +279,7 @@ where
         node.name.clone(),
         ws_uri,
         prometheus_uri,
+        multi_addr,
         node.clone(),
         running_node,
     ))


### PR DESCRIPTION
Add multi_addr support to `NetworkNode`

This is to allow referring other nodes' multi_addr, when setting up the network.
In `zombienet` it was:
```toml
  [[parachains.collators]]
  name = "eve"
  validator = false
  image = "{{COL_IMAGE}}"
  command = "test-parachain"
  args = ["--reserved-only", "--reserved-nodes {{'dave'|zombie('multiAddress')}}"]
```
In `zombienet-sdk` could be like as follows:
```rust
// Spin network
(..)
// Get dave's multi_addr
let dave_multi_address = network.get_node("dave")?.multi_addr().to_string();

// Add eve to the network
let eve_options = AddCollatorOptions {
	is_validator: false,
	args: vec![
		("--reserved-only").into(),
		(format!("--reserved-nodes={dave_multi_address}").as_str()).into(),
	],
	..Default::default()
};
network.add_collator("eve", eve_options, PARA_ID).await?;
```