### PR TITLE
implement context replacement

### DIFF
--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -204,7 +204,7 @@ where
             parachain: None,
             bootnodes_addr: &vec![],
             wait_ready: false,
-            nodes_by_name: json!({})
+            nodes_by_name: json!({}),
         };
 
         let global_files_to_inject = vec![TransferedFile::new(

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -31,6 +31,7 @@ use provider::{
     types::{ProviderCapabilities, TransferedFile},
     DynProvider,
 };
+use serde_json::json;
 use support::fs::{FileSystem, FileSystemError};
 use tokio::time::timeout;
 use tracing::{debug, info, trace};
@@ -203,6 +204,7 @@ where
             parachain: None,
             bootnodes_addr: &vec![],
             wait_ready: false,
+            nodes_by_name: json!({})
         };
 
         let global_files_to_inject = vec![TransferedFile::new(
@@ -232,7 +234,7 @@ where
 
         // Calculate the bootnodes addr from the running nodes
         let mut bootnodes_addr: Vec<String> = vec![];
-        for node in futures::future::try_join_all(spawning_tasks).await? {
+        for mut node in futures::future::try_join_all(spawning_tasks).await? {
             let ip = node.inner.ip().await?;
             let port = if ctx.ns.capabilities().use_default_ports_in_cmd {
                 P2P_PORT
@@ -240,6 +242,8 @@ where
                 node.spec.p2p_port.0
             };
             let bootnode_multiaddr = generate_bootnode_addr(&node, &ip, port)?;
+            node.set_multiaddr(&bootnode_multiaddr);
+
             bootnodes_addr.push(bootnode_multiaddr);
 
             // Is used in the register_para_options (We need to get this from the relay and not the collators)
@@ -247,7 +251,8 @@ where
                 node_ws_url.clone_from(&node.ws_uri)
             }
 
-            // Add the node to the `Network` instance
+            // Add the node to the  context and `Network` instance
+            ctx.nodes_by_name[node.name().to_owned()] = serde_json::to_value(&node)?;
             network.add_running_node(node, None);
         }
 
@@ -266,7 +271,8 @@ where
             .map(|node| spawner::spawn_node(node, global_files_to_inject.clone(), &ctx));
 
         for node in futures::future::try_join_all(spawning_tasks).await? {
-            // Add the node to the `Network` instance
+            // Add the node to the  context and `Network` instance
+            ctx.nodes_by_name[node.name().to_owned()] = serde_json::to_value(&node)?;
             network.add_running_node(node, None);
         }
 
@@ -299,16 +305,19 @@ where
             // Calculate the bootnodes addr from the running nodes
             let mut bootnodes_addr: Vec<String> = vec![];
             let mut running_nodes: Vec<NetworkNode> = vec![];
-            for node in futures::future::try_join_all(spawning_tasks).await? {
+            for mut node in futures::future::try_join_all(spawning_tasks).await? {
                 let ip = node.inner.ip().await?;
                 let port = if ctx.ns.capabilities().use_default_ports_in_cmd {
                     P2P_PORT
                 } else {
                     node.spec.p2p_port.0
                 };
-                let bootnode_multiaddr = generate_bootnode_addr(&node, &ip, port)?;
-                bootnodes_addr.push(bootnode_multiaddr);
 
+                let bootnode_multiaddr = generate_bootnode_addr(&node, &ip, port)?;
+                node.set_multiaddr(&bootnode_multiaddr);
+
+                bootnodes_addr.push(bootnode_multiaddr);
+                ctx_para.nodes_by_name[node.name().to_owned()] = serde_json::to_value(&node)?;
                 running_nodes.push(node);
             }
 

--- a/crates/orchestrator/src/network.rs
+++ b/crates/orchestrator/src/network.rs
@@ -176,6 +176,7 @@ impl<T: FileSystem> Network<T> {
             parachain: None,
             bootnodes_addr: &vec![],
             wait_ready: true,
+            nodes_by_name: serde_json::to_value(&self.nodes_by_name)?,
         };
 
         let global_files_to_inject = vec![TransferedFile::new(
@@ -269,6 +270,7 @@ impl<T: FileSystem> Network<T> {
             parachain: Some(spec),
             bootnodes_addr: &vec![],
             wait_ready: true,
+            nodes_by_name: serde_json::to_value(&self.nodes_by_name)?,
         };
 
         let relaychain_spec_path = if let Some(chain_spec_custom_path) = &options.chain_spec_relay {
@@ -449,6 +451,7 @@ impl<T: FileSystem> Network<T> {
             ns: &self.ns,
             scoped_fs: &scoped_fs,
             wait_ready: false,
+            nodes_by_name: serde_json::to_value(&self.nodes_by_name)?,
         };
 
         // Register the parachain to the running network

--- a/crates/orchestrator/src/network/node.rs
+++ b/crates/orchestrator/src/network/node.rs
@@ -65,12 +65,12 @@ impl NetworkNode {
             prometheus_uri: prometheus_uri.into(),
             inner,
             spec,
-            multiaddr: multiaddr,
+            multiaddr,
             metrics_cache: Arc::new(Default::default()),
         }
     }
 
-    pub(crate) fn set_multiaddr(&mut self, multiaddr: impl Into<String> ) {
+    pub(crate) fn set_multiaddr(&mut self, multiaddr: impl Into<String>) {
         self.multiaddr = Some(multiaddr.into())
     }
 

--- a/crates/orchestrator/src/network/node.rs
+++ b/crates/orchestrator/src/network/node.rs
@@ -31,6 +31,7 @@ pub struct NetworkNode {
     pub(crate) spec: NodeSpec,
     pub(crate) name: String,
     pub(crate) ws_uri: String,
+    pub(crate) multiaddr: Option<String>,
     pub(crate) prometheus_uri: String,
     #[serde(skip)]
     metrics_cache: Arc<RwLock<MetricMap>>,
@@ -54,6 +55,7 @@ impl NetworkNode {
         name: T,
         ws_uri: T,
         prometheus_uri: T,
+        multiaddr: Option<String>,
         spec: NodeSpec,
         inner: DynNode,
     ) -> Self {
@@ -63,8 +65,13 @@ impl NetworkNode {
             prometheus_uri: prometheus_uri.into(),
             inner,
             spec,
+            multiaddr: multiaddr,
             metrics_cache: Arc::new(Default::default()),
         }
+    }
+
+    pub(crate) fn set_multiaddr(&mut self, multiaddr: impl Into<String> ) {
+        self.multiaddr = Some(multiaddr.into())
     }
 
     pub fn name(&self) -> &str {

--- a/crates/orchestrator/src/spawner.rs
+++ b/crates/orchestrator/src/spawner.rs
@@ -7,7 +7,9 @@ use provider::{
     types::{SpawnNodeOptions, TransferedFile},
     DynNamespace,
 };
-use support::{constants::THIS_IS_A_BUG, fs::FileSystem, replacer::apply_running_network_replacements};
+use support::{
+    constants::THIS_IS_A_BUG, fs::FileSystem, replacer::apply_running_network_replacements,
+};
 use tracing::info;
 
 use crate::{
@@ -163,9 +165,10 @@ where
     };
 
     // apply running networ replacements
-    let args: Vec<String> = args.iter().map(|arg| {
-        apply_running_network_replacements(arg, &ctx.nodes_by_name)
-    }).collect();
+    let args: Vec<String> = args
+        .iter()
+        .map(|arg| apply_running_network_replacements(arg, &ctx.nodes_by_name))
+        .collect();
 
     info!(
         "🚀 {}, spawning.... with command: {} {}",

--- a/crates/support/Cargo.toml
+++ b/crates/support/Cargo.toml
@@ -24,3 +24,5 @@ nix = { workspace = true, features = ["signal"] }
 rand = { workspace = true }
 regex = { workspace = true }
 tracing = { workspace = true }
+lazy_static = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/support/src/replacer.rs
+++ b/crates/support/src/replacer.rs
@@ -9,10 +9,8 @@ use crate::constants::{SHOULD_COMPILE, THIS_IS_A_BUG};
 lazy_static! {
     static ref RE: Regex = Regex::new(r#"\{\{([a-zA-Z0-9_]*)\}\}"#)
         .unwrap_or_else(|_| panic!("{}, {}", SHOULD_COMPILE, THIS_IS_A_BUG));
-
     static ref TOKEN_PLACEHOLDER: Regex = Regex::new(r#"\{\{ZOMBIE:(.*?):(.*?)\}\}"#)
         .unwrap_or_else(|_| panic!("{}, {}", SHOULD_COMPILE, THIS_IS_A_BUG));
-
     static ref PLACEHOLDER_COMPAT: HashMap<&'static str, &'static str> = {
         let mut m = HashMap::new();
         m.insert("multiAddress", "multiaddr");

--- a/crates/support/src/replacer.rs
+++ b/crates/support/src/replacer.rs
@@ -1,14 +1,29 @@
 use std::collections::HashMap;
-
+use lazy_static::lazy_static;
 use regex::{Captures, Regex};
+use tracing::{trace, warn};
 
-use crate::constants::{THIS_IS_A_BUG, VALID_REGEX};
+use crate::constants::{THIS_IS_A_BUG, SHOULD_COMPILE};
+
+lazy_static! {
+    static ref RE: Regex = Regex::new(r#"\{\{([a-zA-Z0-9_]*)\}\}"#)
+        .expect(&format!("{}, {}", SHOULD_COMPILE, THIS_IS_A_BUG));
+
+    static ref TOKEN_PLACEHOLDER: Regex = Regex::new(r#"\{\{ZOMBIE:(.*?):(.*?)\}\}"#)
+        .expect(&format!("{}, {}", SHOULD_COMPILE, THIS_IS_A_BUG));
+
+    static ref PLACEHOLDER_COMPAT: HashMap<&'static str, &'static str> = {
+            let mut m = HashMap::new();
+            m.insert("multiAddress", "multiaddr");
+            m.insert("wsUri", "ws_uri");
+
+            m
+        };
+
+}
 
 pub fn apply_replacements(text: &str, replacements: &HashMap<&str, &str>) -> String {
-    let re = Regex::new(r#"\{\{([a-zA-Z0-9_]*)\}\}"#)
-        .unwrap_or_else(|_| panic!("{} {}", VALID_REGEX, THIS_IS_A_BUG));
-
-    let augmented_text = re.replace_all(text, |caps: &Captures| {
+    let augmented_text = RE.replace_all(text, |caps: &Captures| {
         if let Some(replacements_value) = replacements.get(&caps[1]) {
             replacements_value.to_string()
         } else {
@@ -20,10 +35,7 @@ pub fn apply_replacements(text: &str, replacements: &HashMap<&str, &str>) -> Str
 }
 
 pub fn apply_env_replacements(text: &str) -> String {
-    let re = Regex::new(r#"\{\{([a-zA-Z0-9_]*)\}\}"#)
-        .unwrap_or_else(|_| panic!("{} {}", VALID_REGEX, THIS_IS_A_BUG));
-
-    let augmented_text = re.replace_all(text, |caps: &Captures| {
+    let augmented_text = RE.replace_all(text, |caps: &Captures| {
         if let Ok(replacements_value) = std::env::var(&caps[1]) {
             replacements_value
         } else {
@@ -34,8 +46,31 @@ pub fn apply_env_replacements(text: &str) -> String {
     augmented_text.to_string()
 }
 
+pub fn apply_running_network_replacements(text: &str, network: &serde_json::Value) -> String {
+    let augmented_text = TOKEN_PLACEHOLDER.replace_all(text, |caps: &Captures| {
+        trace!("appling replacements for caps: {caps:#?}");
+        if let Some(node) = network.get(&caps[1]) {
+            trace!("caps1 {} - node: {node}", &caps[1]);
+            let field = *PLACEHOLDER_COMPAT.get(&caps[2]).unwrap_or(&&caps[2]);
+            if let Some(val) = node.get(&field) {
+                trace!("caps2 {} - node: {node}", field);
+                val.as_str().unwrap_or("Invalid string").to_string()
+            } else {
+                warn!("⚠️ The node with name {} doesn't have the value {} in context", &caps[1], &caps[2]);
+                caps[0].to_string()
+            }
+        } else {
+            warn!("⚠️ No node with name {} in context", &caps[1]);
+            caps[0].to_string()
+        }
+    });
+
+    augmented_text.to_string()
+}
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::*;
 
     #[test]
@@ -92,5 +127,41 @@ mod tests {
         replacements.insert("other", "demo-123");
         let res = apply_replacements(text, &replacements);
         assert_eq!(text.to_string(), res);
+    }
+
+    #[test]
+    fn replace_running_network_should_work() {
+        let network = json!({
+            "alice" : {
+                "multiaddr": "some/demo/127.0.0.1"
+            }
+        });
+
+        let res = apply_running_network_replacements("{{ZOMBIE:alice:multiaddr}}", &network);
+        assert_eq!(res.as_str(), "some/demo/127.0.0.1");
+    }
+
+    #[test]
+    fn replace_running_network_with_compat_should_work() {
+        let network = json!({
+            "alice" : {
+                "multiaddr": "some/demo/127.0.0.1"
+            }
+        });
+
+        let res = apply_running_network_replacements("{{ZOMBIE:alice:multiAddress}}", &network);
+        assert_eq!(res.as_str(), "some/demo/127.0.0.1");
+    }
+
+    #[test]
+    fn replace_running_network_with_missing_field_should_not_replace_nothing() {
+        let network = json!({
+            "alice" : {
+                "multiaddr": "some/demo/127.0.0.1"
+            }
+        });
+
+        let res = apply_running_network_replacements("{{ZOMBIE:alice:someField}}", &network);
+        assert_eq!(res.as_str(), "{{ZOMBIE:alice:someField}}");
     }
 }

--- a/crates/support/src/replacer.rs
+++ b/crates/support/src/replacer.rs
@@ -1,26 +1,24 @@
 use std::collections::HashMap;
+
 use lazy_static::lazy_static;
 use regex::{Captures, Regex};
 use tracing::{trace, warn};
 
-use crate::constants::{THIS_IS_A_BUG, SHOULD_COMPILE};
+use crate::constants::{SHOULD_COMPILE, THIS_IS_A_BUG};
 
 lazy_static! {
     static ref RE: Regex = Regex::new(r#"\{\{([a-zA-Z0-9_]*)\}\}"#)
         .expect(&format!("{}, {}", SHOULD_COMPILE, THIS_IS_A_BUG));
-
     static ref TOKEN_PLACEHOLDER: Regex = Regex::new(r#"\{\{ZOMBIE:(.*?):(.*?)\}\}"#)
         .expect(&format!("{}, {}", SHOULD_COMPILE, THIS_IS_A_BUG));
-
     static ref PLACEHOLDER_COMPAT: HashMap<&'static str, &'static str> = {
-            let mut m = HashMap::new();
-            m.insert("multiAddress", "multiaddr");
-            m.insert("wsUri", "ws_uri");
-            m.insert("prometheusUri", "prometheus_uri");
+        let mut m = HashMap::new();
+        m.insert("multiAddress", "multiaddr");
+        m.insert("wsUri", "ws_uri");
+        m.insert("prometheusUri", "prometheus_uri");
 
-            m
-        };
-
+        m
+    };
 }
 
 pub fn apply_replacements(text: &str, replacements: &HashMap<&str, &str>) -> String {
@@ -57,7 +55,10 @@ pub fn apply_running_network_replacements(text: &str, network: &serde_json::Valu
                 trace!("caps2 {} - node: {node}", field);
                 val.as_str().unwrap_or("Invalid string").to_string()
             } else {
-                warn!("⚠️ The node with name {} doesn't have the value {} in context", &caps[1], &caps[2]);
+                warn!(
+                    "⚠️ The node with name {} doesn't have the value {} in context",
+                    &caps[1], &caps[2]
+                );
                 caps[0].to_string()
             }
         } else {

--- a/crates/support/src/replacer.rs
+++ b/crates/support/src/replacer.rs
@@ -8,9 +8,11 @@ use crate::constants::{SHOULD_COMPILE, THIS_IS_A_BUG};
 
 lazy_static! {
     static ref RE: Regex = Regex::new(r#"\{\{([a-zA-Z0-9_]*)\}\}"#)
-        .expect(&format!("{}, {}", SHOULD_COMPILE, THIS_IS_A_BUG));
+        .unwrap_or_else(|_| panic!("{}, {}", SHOULD_COMPILE, THIS_IS_A_BUG));
+
     static ref TOKEN_PLACEHOLDER: Regex = Regex::new(r#"\{\{ZOMBIE:(.*?):(.*?)\}\}"#)
-        .expect(&format!("{}, {}", SHOULD_COMPILE, THIS_IS_A_BUG));
+        .unwrap_or_else(|_| panic!("{}, {}", SHOULD_COMPILE, THIS_IS_A_BUG));
+
     static ref PLACEHOLDER_COMPAT: HashMap<&'static str, &'static str> = {
         let mut m = HashMap::new();
         m.insert("multiAddress", "multiaddr");
@@ -51,7 +53,7 @@ pub fn apply_running_network_replacements(text: &str, network: &serde_json::Valu
         if let Some(node) = network.get(&caps[1]) {
             trace!("caps1 {} - node: {node}", &caps[1]);
             let field = *PLACEHOLDER_COMPAT.get(&caps[2]).unwrap_or(&&caps[2]);
-            if let Some(val) = node.get(&field) {
+            if let Some(val) = node.get(field) {
                 trace!("caps2 {} - node: {node}", field);
                 val.as_str().unwrap_or("Invalid string").to_string()
             } else {

--- a/crates/support/src/replacer.rs
+++ b/crates/support/src/replacer.rs
@@ -16,6 +16,7 @@ lazy_static! {
             let mut m = HashMap::new();
             m.insert("multiAddress", "multiaddr");
             m.insert("wsUri", "ws_uri");
+            m.insert("prometheusUri", "prometheus_uri");
 
             m
         };


### PR DESCRIPTION
Add support for context (from runtime network replacements) as we have in v1.

__Migration path__:

Instead of using the v1 filters (from nunjucks)
```
{{'alice'|zombie('multiAddress')}}
```

you need to use the direct form that v1 use behind the filer of

```
{{ZOMBIE:alice:multiAddress}}
```

In the form 
```
{{ZOMBIE:<node name>:<node field>
```

Available fields are:
- multiAddres / multiaddr
- wsUri / ws_uri
- prometheusUri / prometheus_uri
- name

cc: @lrubasze 