### PR TITLE
Log lines parsing improvements

### DIFF
--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -44,6 +44,7 @@ prom-metrics-parser = { workspace = true }
 
 [dev-dependencies]
 toml = { workspace = true }
+async-trait = { workspace = true }
 
 [features]
 pjs = ["dep:pjs-rs"]

--- a/crates/orchestrator/src/network/node.rs
+++ b/crates/orchestrator/src/network/node.rs
@@ -370,6 +370,10 @@ impl NetworkNode {
 
     /// Wait until a the number of matching log lines is reach
     /// with timeout (secs)
+    #[deprecated(
+        since = "0.2.32",
+        note = "Use `wait_log_line_count_with_timeout_v2` instead"
+    )]
     pub async fn wait_log_line_count_with_timeout(
         &self,
         substring: impl Into<String>,

--- a/crates/orchestrator/src/network/node.rs
+++ b/crates/orchestrator/src/network/node.rs
@@ -52,6 +52,15 @@ pub enum LogLineCount {
     TargetFailed(u32),
 }
 
+impl LogLineCount {
+    pub fn success(&self) -> bool {
+        match self {
+            Self::TargetReached(..) => true,
+            Self::TargetFailed(..) => false,
+        }
+    }
+}
+
 /// Configuration for controlling log line count waiting behavior.
 ///
 /// Allows specifying a custom predicate on the number of matching log lines,
@@ -900,9 +909,7 @@ mod tests {
 
         mock_provider.logs_push(vec!["stub line 3"]);
 
-        let log_line_count = task.await?;
-
-        assert!(matches!(log_line_count, LogLineCount::TargetReached(0)));
+        assert!(task.await?.success());
 
         Ok(())
     }
@@ -941,9 +948,7 @@ mod tests {
 
         mock_provider.logs_push(vec!["system ready", "system ready", "system ready"]);
 
-        let log_line_count = task.await?;
-
-        assert!(matches!(log_line_count, LogLineCount::TargetReached(3)));
+        assert!(task.await?.success());
 
         Ok(())
     }

--- a/crates/orchestrator/src/network/node.rs
+++ b/crates/orchestrator/src/network/node.rs
@@ -432,14 +432,28 @@ impl NetworkNode {
     ///
     /// # Example
     /// ```rust
+    /// # use std::sync::Arc;
+    /// # use provider::NativeProvider;
+    /// # use support::{fs::local::LocalFileSystem};
+    /// # use zombienet_orchestrator::{Orchestrator, network::node::{NetworkNode, LogLineCountOptions}};
+    /// # use configuration::NetworkConfig;
+    /// # async fn example() -> Result<(), anyhow::Error> {
+    /// #   let provider = NativeProvider::new(LocalFileSystem {});
+    /// #   let orchestrator = Orchestrator::new(LocalFileSystem {}, provider);
+    /// #   let config = NetworkConfig::load_from_toml("config.toml")?;
+    /// #   let network = orchestrator.spawn(config).await?;
+    /// let node = network.get_node("alice")?;
+    /// // Wait (up to 10 seconds) until pattern occurs once
     /// let options = LogLineCountOptions {
-    ///     predicate: Arc::new(|count| count == 0),
+    ///     predicate: Arc::new(|count| count == 1),
     ///     timeout_secs: 10,
-    ///     wait_until_timeout_elapses: true,
+    ///     wait_until_timeout_elapses: false,
     /// };
-    /// let result = logger
+    /// let result = node
     ///     .wait_log_line_count_with_timeout_v2("error", false, options)
     ///     .await?;
+    /// #   Ok(())
+    /// # }
     /// ```
     pub async fn wait_log_line_count_with_timeout_v2(
         &self,

--- a/crates/orchestrator/src/network/node.rs
+++ b/crates/orchestrator/src/network/node.rs
@@ -389,28 +389,6 @@ impl NetworkNode {
         }
     }
 
-    /// Wait until a the number of matching log lines is reach
-    /// with timeout (secs)
-    #[deprecated(
-        since = "0.2.32",
-        note = "Use `wait_log_line_count_with_timeout_v2` instead"
-    )]
-    pub async fn wait_log_line_count_with_timeout(
-        &self,
-        substring: impl Into<String>,
-        is_glob: bool,
-        count: usize,
-        timeout_secs: impl Into<u64>,
-    ) -> Result<(), anyhow::Error> {
-        let secs = timeout_secs.into();
-        debug!("waiting until match {count} lines");
-        tokio::time::timeout(
-            Duration::from_secs(secs),
-            self.wait_log_line_count(substring, is_glob, count),
-        )
-        .await?
-    }
-
     /// Waits until the number of matching log lines satisfies a custom condition,
     /// optionally waiting for the entire duration of the timeout.
     ///
@@ -449,12 +427,12 @@ impl NetworkNode {
     ///     wait_until_timeout_elapses: false,
     /// };
     /// let result = node
-    ///     .wait_log_line_count_with_timeout_v2("error", false, options)
+    ///     .wait_log_line_count_with_timeout("error", false, options)
     ///     .await?;
     /// #   Ok(())
     /// # }
     /// ```
-    pub async fn wait_log_line_count_with_timeout_v2(
+    pub async fn wait_log_line_count_with_timeout(
         &self,
         substring: impl Into<String>,
         is_glob: bool,
@@ -754,7 +732,7 @@ mod tests {
         };
 
         let log_line_count = mock_node
-            .wait_log_line_count_with_timeout_v2("system ready", false, options)
+            .wait_log_line_count_with_timeout("system ready", false, options)
             .await?;
 
         assert!(matches!(log_line_count, LogLineCount::TargetReached(1)));
@@ -791,7 +769,7 @@ mod tests {
         let task = tokio::spawn({
             async move {
                 mock_node
-                    .wait_log_line_count_with_timeout_v2("system ready", false, options)
+                    .wait_log_line_count_with_timeout("system ready", false, options)
                     .await
                     .unwrap()
             }
@@ -835,7 +813,7 @@ mod tests {
         };
 
         let log_line_count = mock_node
-            .wait_log_line_count_with_timeout_v2("system ready", false, options)
+            .wait_log_line_count_with_timeout("system ready", false, options)
             .await?;
 
         assert!(matches!(log_line_count, LogLineCount::TargetFailed(1)));
@@ -872,7 +850,7 @@ mod tests {
         let task = tokio::spawn({
             async move {
                 mock_node
-                    .wait_log_line_count_with_timeout_v2("system ready", false, options)
+                    .wait_log_line_count_with_timeout("system ready", false, options)
                     .await
                     .unwrap()
             }
@@ -907,7 +885,7 @@ mod tests {
         let task = tokio::spawn({
             async move {
                 mock_node
-                    .wait_log_line_count_with_timeout_v2(
+                    .wait_log_line_count_with_timeout(
                         "system ready",
                         false,
                         // Wait until timeout and make sure pattern occurred zero times
@@ -953,7 +931,7 @@ mod tests {
         let task = tokio::spawn({
             async move {
                 mock_node
-                    .wait_log_line_count_with_timeout_v2("system ready", false, options)
+                    .wait_log_line_count_with_timeout("system ready", false, options)
                     .await
                     .unwrap()
             }


### PR DESCRIPTION
This PR improves log parsing by introducing some changes `wait_log_line_count_with_timeout()`.

The method searches log lines for a given substring or glob pattern,
and evaluates the number of matching lines using a user-provided predicate function.
Optionally, it can wait for the full timeout duration to ensure the condition
holds consistently (e.g., for verifying absence of logs).

It uses `LogLineCountOptions` struct to configure the timeout, match count predicate and full-duration waiting.

It returns enum `LogLineCount`:
* `Ok(LogLineCount::TargetReached(n))` if the predicate was satisfied within the timeout,
* `Ok(LogLineCount::TargetFails(n))` if the predicate was not satisfied in time,
* `Err(e)` if an error occurred during log retrieval or matching.

Additionally added some tests to verify the changes.

NOTE!
This is a breaking change (method signature changed) and the clients using `wait_log_line_count_with_timeout()` update their tests.


