### PR TITLE
add logic to handle `devStakers` key without override the validator count

### DIFF
--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -1396,7 +1396,6 @@ mod tests {
         }})
     }
 
-
     fn chain_spec_with_dev_stakers() -> serde_json::Value {
         json!({"genesis": {
             "runtimeGenesis" : {
@@ -1444,7 +1443,9 @@ mod tests {
         let pointer = get_runtime_config_pointer(&chain_spec_json).unwrap();
         clear_authorities(&pointer, &mut chain_spec_json);
 
-        let validator_count = chain_spec_json.pointer(&format!("{pointer}/staking/validatorCount")).unwrap();
+        let validator_count = chain_spec_json
+            .pointer(&format!("{pointer}/staking/validatorCount"))
+            .unwrap();
         assert_eq!(validator_count, &json!(500));
     }
 
@@ -1455,7 +1456,9 @@ mod tests {
         let pointer = get_runtime_config_pointer(&chain_spec_json).unwrap();
         clear_authorities(&pointer, &mut chain_spec_json);
 
-        let validator_count = chain_spec_json.pointer(&format!("{pointer}/staking/validatorCount")).unwrap();
+        let validator_count = chain_spec_json
+            .pointer(&format!("{pointer}/staking/validatorCount"))
+            .unwrap();
         assert_eq!(validator_count, &json!(0));
     }
 

--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 // TODO: (javier) move to state
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub enum Context {
     Relay,
     Para,
@@ -1003,11 +1003,14 @@ fn clear_authorities(runtime_config_ptr: &str, chain_spec_json: &mut serde_json:
             val["collatorSelection"]["invulnerables"] = json!([]);
         }
 
-        // clear staking
+        // clear staking but not `validatorCount` if `devStakers` is set
         if val.get("staking").is_some() {
-            val["staking"]["stakers"] = json!([]);
             val["staking"]["invulnerables"] = json!([]);
-            val["staking"]["validatorCount"] = json!(0);
+            val["staking"]["stakers"] = json!([]);
+
+            if val["staking"]["devStakers"] == json!(null) {
+                val["staking"]["validatorCount"] = json!(0);
+            }
         }
     } else {
         unreachable!("pointer to runtime config should be valid!")
@@ -1393,6 +1396,37 @@ mod tests {
         }})
     }
 
+
+    fn chain_spec_with_dev_stakers() -> serde_json::Value {
+        json!({"genesis": {
+            "runtimeGenesis" : {
+                "patch": {
+                    "staking": {
+                        "activeEra": [
+                            0,
+                            0,
+                            0
+                        ],
+                        "canceledPayout": 0,
+                        "devStakers": [
+                            2000,
+                            25000
+                        ],
+                        "forceEra": "NotForcing",
+                        "invulnerables": [],
+                        "maxNominatorCount": null,
+                        "maxValidatorCount": null,
+                        "minNominatorBond": 0,
+                        "minValidatorBond": 0,
+                        "slashRewardFraction": 0,
+                        "stakers": [],
+                        "validatorCount": 500
+                    },
+                }
+            }
+        }})
+    }
+
     #[test]
     fn get_min_stake_works() {
         let mut chain_spec_json = chain_spec_with_stake();
@@ -1402,6 +1436,29 @@ mod tests {
 
         assert_eq!(100000000000001, min);
     }
+
+    #[test]
+    fn dev_stakers_not_override_count_works() {
+        let mut chain_spec_json = chain_spec_with_dev_stakers();
+
+        let pointer = get_runtime_config_pointer(&chain_spec_json).unwrap();
+        clear_authorities(&pointer, &mut chain_spec_json);
+
+        let validator_count = chain_spec_json.pointer(&format!("{pointer}/staking/validatorCount")).unwrap();
+        assert_eq!(validator_count, &json!(500));
+    }
+
+    #[test]
+    fn dev_stakers_override_count_works() {
+        let mut chain_spec_json = chain_spec_with_stake();
+
+        let pointer = get_runtime_config_pointer(&chain_spec_json).unwrap();
+        clear_authorities(&pointer, &mut chain_spec_json);
+
+        let validator_count = chain_spec_json.pointer(&format!("{pointer}/staking/validatorCount")).unwrap();
+        assert_eq!(validator_count, &json!(0));
+    }
+
     #[test]
     fn overrides_from_toml_works() {
         use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Only clear `validatorCount` IFF staking is set but __not__ `devStakers`.

cc: @tdimitrov 