### PR TITLE
Support multiple args

### DIFF
--- a/crates/configuration/src/shared/types.rs
+++ b/crates/configuration/src/shared/types.rs
@@ -502,7 +502,6 @@ impl de::Visitor<'_> for ArgVisitor {
                         .collect();
                     return Ok(Arg::Array(name_prefix, items));
                 } else {
-                    // return Ok(Arg::Option(name, val.to_string()));
                     return Ok(Arg::Option(name_prefix, val.to_string()));
                 }
             }
@@ -564,7 +563,6 @@ mod tests {
     #[test]
     fn test_arg_array_roundtrip() {
         let arg = Arg::from(("items", ["a", "b", "c"].as_slice()));
-        // let arg = Arg::from(("--items", vec!["a", "b", "c"]));
 
         let serialized = serde_json::to_string(&arg).unwrap();
         println!("serialized = {}", serialized);

--- a/crates/orchestrator/src/generators/command.rs
+++ b/crates/orchestrator/src/generators/command.rs
@@ -97,6 +97,7 @@ pub fn generate_for_cumulus_node(
         if let Some(index) = args.iter().position(|arg| match arg {
             Arg::Flag(flag) => flag.eq("--"),
             Arg::Option(..) => false,
+            Arg::Array(..) => false,
         }) {
             (collator_args, full_node_args) = args.split_at(index);
         } else {
@@ -157,6 +158,11 @@ pub fn generate_for_cumulus_node(
                     Some(vec![k.to_owned(), v.to_owned()])
                 }
             },
+            Arg::Array(k, v) => {
+                let mut args = vec![k.to_owned()];
+                args.extend(v.to_owned());
+                Some(args)
+            },
         })
         .flatten()
         .collect::<Vec<String>>();
@@ -189,6 +195,11 @@ pub fn generate_for_cumulus_node(
                 } else {
                     Some(vec![k.to_owned(), v.to_owned()])
                 }
+            },
+            Arg::Array(k, v) => {
+                let mut args = vec![k.to_owned()];
+                args.extend(v.to_owned());
+                Some(args)
             },
         })
         .flatten()
@@ -300,6 +311,7 @@ pub fn generate_for_node(
                 None
             }
         },
+        Arg::Array(..) => None,
     }) {
         let mut parts = listen_val.split('/').collect::<Vec<&str>>();
         // TODO: move this to error
@@ -348,6 +360,11 @@ pub fn generate_for_node(
                 } else {
                     Some(vec![k.to_owned(), v.to_owned()])
                 }
+            },
+            Arg::Array(k, v) => {
+                let mut args = vec![k.to_owned()];
+                args.extend(v.to_owned());
+                Some(args)
             },
         })
         .flatten()

--- a/crates/orchestrator/src/generators/para_artifact.rs
+++ b/crates/orchestrator/src/generators/para_artifact.rs
@@ -132,6 +132,10 @@ impl ParaArtifact {
                         args.push(flag.into());
                         args.push(flag_value.into());
                     },
+                    configuration::types::Arg::Array(flag, values) => {
+                        args.push(flag.into());
+                        values.iter().for_each(|v| args.push(v.into()));
+                    },
                 }
             }
 

--- a/crates/orchestrator/src/network/node.rs
+++ b/crates/orchestrator/src/network/node.rs
@@ -31,7 +31,7 @@ pub struct NetworkNode {
     pub(crate) spec: NodeSpec,
     pub(crate) name: String,
     pub(crate) ws_uri: String,
-    pub(crate) multiaddr: Option<String>,
+    pub(crate) multiaddr: String,
     pub(crate) prometheus_uri: String,
     #[serde(skip)]
     metrics_cache: Arc<RwLock<MetricMap>>,
@@ -107,7 +107,7 @@ impl NetworkNode {
         name: T,
         ws_uri: T,
         prometheus_uri: T,
-        multiaddr: Option<String>,
+        multiaddr: T,
         spec: NodeSpec,
         inner: DynNode,
     ) -> Self {
@@ -117,13 +117,13 @@ impl NetworkNode {
             prometheus_uri: prometheus_uri.into(),
             inner,
             spec,
-            multiaddr,
+            multiaddr: multiaddr.into(),
             metrics_cache: Arc::new(Default::default()),
         }
     }
 
     pub(crate) fn set_multiaddr(&mut self, multiaddr: impl Into<String>) {
-        self.multiaddr = Some(multiaddr.into())
+        self.multiaddr = multiaddr.into();
     }
 
     pub fn name(&self) -> &str {
@@ -142,8 +142,8 @@ impl NetworkNode {
         &self.ws_uri
     }
 
-    pub fn multiaddr(&self) -> Option<&str> {
-        self.multiaddr.as_deref()
+    pub fn multiaddr(&self) -> &str {
+        self.multiaddr.as_ref()
     }
 
     // Subxt
@@ -712,7 +712,7 @@ mod tests {
             "node1",
             "ws_uri",
             "prometheus_uri",
-            None,
+            "multiaddr",
             NodeSpec::default(),
             mock_provider.clone(),
         );
@@ -747,7 +747,7 @@ mod tests {
             "node1",
             "ws_uri",
             "prometheus_uri",
-            None,
+            "multiaddr",
             NodeSpec::default(),
             mock_provider.clone(),
         );
@@ -793,7 +793,7 @@ mod tests {
             "node1",
             "ws_uri",
             "prometheus_uri",
-            None,
+            "multiaddr",
             NodeSpec::default(),
             mock_provider.clone(),
         );
@@ -828,7 +828,7 @@ mod tests {
             "node1",
             "ws_uri",
             "prometheus_uri",
-            None,
+            "multiaddr",
             NodeSpec::default(),
             mock_provider.clone(),
         );
@@ -875,7 +875,7 @@ mod tests {
             "node1",
             "ws_uri",
             "prometheus_uri",
-            None,
+            "multiaddr",
             NodeSpec::default(),
             mock_provider.clone(),
         );
@@ -914,7 +914,7 @@ mod tests {
             "node1",
             "ws_uri",
             "prometheus_uri",
-            None,
+            "multiaddr",
             NodeSpec::default(),
             mock_provider.clone(),
         );

--- a/crates/orchestrator/src/spawner.rs
+++ b/crates/orchestrator/src/spawner.rs
@@ -253,6 +253,14 @@ where
         }
     }
 
+    let multiaddr = generators::generate_node_bootnode_addr(
+        &node.peer_id,
+        &ip_to_use,
+        node.p2p_port.0,
+        running_node.args().as_ref(),
+        &node.p2p_cert_hash,
+    )?;
+
     let ws_uri = format!("ws://{}:{}", ip_to_use, rpc_port_external);
     let prometheus_uri = format!("http://{}:{}/metrics", ip_to_use, prometheus_port_external);
     info!("🚀 {}, should be running now", node.name);
@@ -280,7 +288,7 @@ where
         node.name.clone(),
         ws_uri,
         prometheus_uri,
-        None,
+        multiaddr,
         node.clone(),
         running_node,
     ))


### PR DESCRIPTION
Changes:
- Add array variant for `Arg` type
This is useful for parameters, which might accept multiple values, eg.
"--bootnodes", "--relay-chain-rpc-url"
Example:
```
--relay-chain-rpc-url ws://127.0.0.1:65168 ws://127.0.0.1:65170  ws://127.0.0.1:65172 
```
Also added some tests for serialize/deserialize `Arg` type.

Additional changes:
- Always calculate `multiaddr` for spawned node
Some tests expected multiaddr to be available, but it was None. Having `multiaddrs` in node's context does not harm :)