### PR TITLE
Allow insecure urls for RPC clients

### DIFF
--- a/crates/orchestrator/src/network/node.rs
+++ b/crates/orchestrator/src/network/node.rs
@@ -159,7 +159,11 @@ impl NetworkNode {
 
     /// Get the rpc client for the node
     pub async fn rpc(&self) -> Result<RpcClient, subxt::Error> {
-        RpcClient::from_url(&self.ws_uri).await
+        if subxt::utils::url_is_secure(&self.ws_uri)? {
+            RpcClient::from_url(&self.ws_uri).await
+        } else {
+            RpcClient::from_insecure_url(&self.ws_uri).await
+        }
     }
 
     /// Get the [online client](subxt::client::OnlineClient) for the node

--- a/crates/orchestrator/src/network/parachain.rs
+++ b/crates/orchestrator/src/network/parachain.rs
@@ -158,7 +158,12 @@ impl Parachain {
                     options.node_ws_url.as_str()
                 )
             })?;
-        let api = OnlineClient::<SubstrateConfig>::from_url(options.node_ws_url).await?;
+
+        let api = if subxt::utils::url_is_secure(&options.node_ws_url)? {
+            OnlineClient::<SubstrateConfig>::from_url(options.node_ws_url).await?
+        } else {
+            OnlineClient::<SubstrateConfig>::from_insecure_url(options.node_ws_url).await?
+        };
 
         let schedule_para = subxt::dynamic::tx(
             "ParasSudoWrapper",


### PR DESCRIPTION
This is especially useful for CI, which spins nodes using Kubernetes provider and nodes don't have localhost IP addresses, which are not considered secure. This was not the case for `native` provider, which uses localhost addresses.