### PR TITLE
Improve context replacements

### DIFF
--- a/crates/orchestrator/src/generators/command.rs
+++ b/crates/orchestrator/src/generators/command.rs
@@ -73,9 +73,8 @@ pub fn generate_for_cumulus_node(
         let bootnodes = bootnodes_addresses
             .iter()
             .map(|m| m.to_string())
-            .collect::<Vec<String>>()
-            .join(" ");
-        tmp_args.push(bootnodes)
+            .collect::<Vec<String>>();
+        tmp_args.extend(bootnodes)
     }
 
     // ports
@@ -118,7 +117,7 @@ pub fn generate_for_cumulus_node(
     let full_bootnodes = [node_specific_bootnodes, options.bootnode_addr].concat();
     if !full_bootnodes.is_empty() {
         tmp_args.push("--bootnodes".into());
-        tmp_args.push(full_bootnodes.join(" "));
+        tmp_args.extend(full_bootnodes);
     }
 
     let mut full_node_p2p_needs_to_be_injected = true;
@@ -284,9 +283,8 @@ pub fn generate_for_node(
         let bootnodes = bootnodes_addresses
             .iter()
             .map(|m| m.to_string())
-            .collect::<Vec<String>>()
-            .join(" ");
-        tmp_args.push(bootnodes)
+            .collect::<Vec<String>>();
+        tmp_args.extend(bootnodes)
     }
 
     // ports
@@ -340,7 +338,7 @@ pub fn generate_for_node(
     let full_bootnodes = [node_specific_bootnodes, options.bootnode_addr].concat();
     if !full_bootnodes.is_empty() {
         tmp_args.push("--bootnodes".into());
-        tmp_args.push(full_bootnodes.join(" "));
+        tmp_args.extend(full_bootnodes);
     }
 
     // add the rest of the args


### PR DESCRIPTION
# Changes:
- Switched to sequential node spawning in order to allow referring to other nodes within the same group
- Extend argument list with other argument list instead of adding arguments joined with " ", 

# More details
This is to cover cases  where nodes spawned in one shot one group refer to the other nodes within that group.
Example:
- `alice` - spawned separately as a bootnode, added to the context
- `bob`, `charlie`, `dave`
`dave` refers to `alice`, `bob` and `charlie`
  - **before** 
Spawned as remaining nodes in one shot. their info were added to the context after all of them were spawned.
   - **now**
Nodes spawned sequentially and the node info is added directly after node is spawned.

```rust
let config = NetworkConfigBuilder::new()
.with_relaychain(|r| {
	r.with_chain("rococo-local")
		.with_default_command("polkadot")
		.with_default_image(images.polkadot.as_str())
		.with_default_args(vec![("-lparachain=debug").into()])
		.with_node(|node| node.with_name("alice"))
		.with_node(|node| node.with_name("bob"))
		.with_node(|node| node.with_name("charlie"))
		.with_node(|node| {
			node.with_name("dave").with_args(vec![
				("-lparachain=debug").into(),
				("--no-beefy").into(),
				("--reserved-only").into(),
				(
					"--reserved-nodes",
					vec![
						"{{ZOMBIE:alice:multiaddr}}",
						"{{ZOMBIE:bob:multiaddr}}",
						"{{ZOMBIE:charlie:multiaddr}}",
					],
				).into(),
				("--sync", "warp").into(),
			])
		})
})
```
