### PR TITLE
feat, allow spawn seq.

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -14,7 +14,7 @@ struct Args {
 enum Commands {
     Spawn {
         config: String,
-        #[arg(short, long, value_parser = clap::builder::PossibleValuesParser::new(["docker", "k8s", "native"]),default_value="docker")]
+        #[arg(short, long, value_parser = clap::builder::PossibleValuesParser::new(["docker", "k8s", "native"]), default_value="docker")]
         provider: String,
     },
 }

--- a/crates/configuration/src/global_settings.rs
+++ b/crates/configuration/src/global_settings.rs
@@ -90,19 +90,20 @@ impl Default for GlobalSettings {
 }
 
 /// A global settings builder, used to build [`GlobalSettings`] declaratively with fields validation.
+#[derive(Default)]
 pub struct GlobalSettingsBuilder {
     config: GlobalSettings,
     errors: Vec<anyhow::Error>,
 }
 
-impl Default for GlobalSettingsBuilder {
-    fn default() -> Self {
-        Self {
-            config: GlobalSettings::default(),
-            errors: vec![],
-        }
-    }
-}
+// impl Default for GlobalSettingsBuilder {
+//     fn default() -> Self {
+//         Self {
+//             config: GlobalSettings::default(),
+//             errors: vec![],
+//         }
+//     }
+// }
 
 impl GlobalSettingsBuilder {
     pub fn new() -> Self {

--- a/crates/configuration/src/global_settings.rs
+++ b/crates/configuration/src/global_settings.rs
@@ -195,7 +195,7 @@ impl GlobalSettingsBuilder {
     pub fn with_spawn_concurrency(self, spawn_concurrency: usize) -> Self {
         Self::transition(
             GlobalSettings {
-                spawn_concurrency: Some(spawn_concurrency.into()),
+                spawn_concurrency: Some(spawn_concurrency),
                 ..self.config
             },
             self.errors,

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -45,6 +45,7 @@ prom-metrics-parser = { workspace = true }
 [dev-dependencies]
 toml = { workspace = true }
 async-trait = { workspace = true }
+lazy_static = { workspace = true }
 
 [features]
 pjs = ["dep:pjs-rs"]

--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -10,7 +10,7 @@ use provider::{
     types::{GenerateFileCommand, GenerateFilesOptions, TransferedFile},
     DynNamespace, ProviderError,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use support::{constants::THIS_IS_A_BUG, fs::FileSystem, replacer::apply_replacements};
 use tokio::process::Command;
@@ -23,7 +23,7 @@ use crate::{
 };
 
 // TODO: (javier) move to state
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum Context {
     Relay,
     Para,
@@ -53,7 +53,7 @@ impl Default for SessionKeyType {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum CommandInContext {
     Local(String),
     Remote(String),
@@ -75,7 +75,7 @@ pub struct ParaGenesisConfig<T: AsRef<Path>> {
     pub(crate) as_parachain: bool,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChainSpec {
     // Name of the spec file, most of the times could be the same as the chain_name. (e.g rococo-local)
     chain_spec_name: String,

--- a/crates/orchestrator/src/generators/para_artifact.rs
+++ b/crates/orchestrator/src/generators/para_artifact.rs
@@ -6,20 +6,20 @@ use provider::{
     types::{GenerateFileCommand, GenerateFilesOptions, TransferedFile},
     DynNamespace,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use support::fs::FileSystem;
 use uuid::Uuid;
 
 use super::errors::GeneratorError;
 use crate::ScopedFilesystem;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum ParaArtifactType {
     Wasm,
     State,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum ParaArtifactBuildOption {
     Path(String),
     Command(String),
@@ -27,7 +27,7 @@ pub(crate) enum ParaArtifactBuildOption {
 }
 
 /// Parachain artifact (could be either the genesis state or genesis wasm)
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ParaArtifact {
     artifact_type: ParaArtifactType,
     build_option: ParaArtifactBuildOption,

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -580,7 +580,7 @@ fn calculate_concurrency(spec: &NetworkSpec) -> Result<(usize, bool), anyhow::Er
             if spawn_concurrency == 1 {
                 (1, false)
             } else if has_tokens(&serde_json::to_string(spec)?) {
-                    (1, true)
+                (1, true)
             } else {
                 (spawn_concurrency, false)
             }
@@ -695,13 +695,11 @@ pub use pjs_helper::PjsResult;
 
 #[cfg(test)]
 mod tests {
-    use tokio::sync::Mutex;
-    use lazy_static::lazy_static;
-
     use configuration::{GlobalSettingsBuilder, NetworkConfigBuilder};
+    use lazy_static::lazy_static;
+    use tokio::sync::Mutex;
 
     use super::*;
-
 
     const ENV_KEY: &str = "ZOMBIE_SPAWN_CONCURRENCY";
     // mutex for test that use env

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -15,6 +15,7 @@ mod spawner;
 
 use std::{
     collections::HashSet,
+    env,
     net::IpAddr,
     path::{Path, PathBuf},
     time::{Duration, SystemTime},
@@ -32,7 +33,10 @@ use provider::{
     DynProvider,
 };
 use serde_json::json;
-use support::fs::{FileSystem, FileSystemError};
+use support::{
+    fs::{FileSystem, FileSystemError},
+    replacer::has_tokens,
+};
 use tokio::time::timeout;
 use tracing::{debug, info, trace, warn};
 
@@ -111,10 +115,14 @@ where
             self.provider.create_namespace().await?
         };
 
+        // set the spawn_concurrency
+        let (spawn_concurrency, limited_by_tokens) = calculate_concurrency(&network_spec)?;
+
         let start_time = SystemTime::now();
         info!("🧰 ns: {}", ns.name());
         info!("🧰 base_dir: {:?}", ns.base_dir());
         info!("🕰 start time: {:?}", start_time);
+        info!("⚙️ spawn concurrency: {spawn_concurrency} (limited by tokens: {limited_by_tokens})");
 
         network_spec
             .populate_nodes_available_args(ns.clone())
@@ -224,28 +232,31 @@ where
         let mut network =
             Network::new_with_relay(r, ns.clone(), self.filesystem.clone(), network_spec.clone());
 
-        let spawning_tasks = bootnodes
-            .iter()
-            .map(|node| spawner::spawn_node(node, global_files_to_inject.clone(), &ctx));
-
-        // Initiate the node_ws_uel which will be later used in the Parachain_with_extrinsic config
+        // Initiate the node_ws_url which will be later used in the Parachain_with_extrinsic config
         let mut node_ws_url: String = "".to_string();
 
         // Calculate the bootnodes addr from the running nodes
         let mut bootnodes_addr: Vec<String> = vec![];
-        for node in futures::future::try_join_all(spawning_tasks).await? {
-            let bootnode_multiaddr = node.multiaddr();
 
-            bootnodes_addr.push(bootnode_multiaddr.to_string());
+        for chunk in bootnodes.chunks(spawn_concurrency) {
+            let spawning_tasks = chunk
+                .iter()
+                .map(|node| spawner::spawn_node(node, global_files_to_inject.clone(), &ctx));
 
-            // Is used in the register_para_options (We need to get this from the relay and not the collators)
-            if node_ws_url.is_empty() {
-                node_ws_url.clone_from(&node.ws_uri)
+            for node in futures::future::try_join_all(spawning_tasks).await? {
+                let bootnode_multiaddr = node.multiaddr();
+
+                bootnodes_addr.push(bootnode_multiaddr.to_string());
+
+                // Is used in the register_para_options (We need to get this from the relay and not the collators)
+                if node_ws_url.is_empty() {
+                    node_ws_url.clone_from(&node.ws_uri)
+                }
+
+                // Add the node to the  context and `Network` instance
+                ctx.nodes_by_name[node.name().to_owned()] = serde_json::to_value(&node)?;
+                network.add_running_node(node, None);
             }
-
-            // Add the node to the  context and `Network` instance
-            ctx.nodes_by_name[node.name().to_owned()] = serde_json::to_value(&node)?;
-            network.add_running_node(node, None);
         }
 
         // Add the bootnodes to the relaychain spec file and ctx
@@ -257,15 +268,16 @@ where
 
         ctx.bootnodes_addr = &bootnodes_addr;
 
-        // spawn the rest of the nodes (TODO: in batches)
-        let spawning_tasks = relaynodes
-            .iter()
-            .map(|node| spawner::spawn_node(node, global_files_to_inject.clone(), &ctx));
+        for chunk in relaynodes.chunks(spawn_concurrency) {
+            let spawning_tasks = chunk
+                .iter()
+                .map(|node| spawner::spawn_node(node, global_files_to_inject.clone(), &ctx));
 
-        for node in futures::future::try_join_all(spawning_tasks).await? {
-            // Add the node to the  context and `Network` instance
-            ctx.nodes_by_name[node.name().to_owned()] = serde_json::to_value(&node)?;
-            network.add_running_node(node, None);
+            for node in futures::future::try_join_all(spawning_tasks).await? {
+                // Add the node to the  context and `Network` instance
+                ctx.nodes_by_name[node.name().to_owned()] = serde_json::to_value(&node)?;
+                network.add_running_node(node, None);
+            }
         }
 
         // spawn paras
@@ -290,19 +302,22 @@ where
                 ..ctx.clone()
             };
 
-            let spawning_tasks = bootnodes.iter().map(|node| {
-                spawner::spawn_node(node, parachain.files_to_inject.clone(), &ctx_para)
-            });
-
             // Calculate the bootnodes addr from the running nodes
             let mut bootnodes_addr: Vec<String> = vec![];
             let mut running_nodes: Vec<NetworkNode> = vec![];
-            for node in futures::future::try_join_all(spawning_tasks).await? {
-                let bootnode_multiaddr = node.multiaddr();
 
-                bootnodes_addr.push(bootnode_multiaddr.to_string());
-                ctx_para.nodes_by_name[node.name().to_owned()] = serde_json::to_value(&node)?;
-                running_nodes.push(node);
+            for chunk in bootnodes.chunks(spawn_concurrency) {
+                let spawning_tasks = chunk.iter().map(|node| {
+                    spawner::spawn_node(node, parachain.files_to_inject.clone(), &ctx_para)
+                });
+
+                for node in futures::future::try_join_all(spawning_tasks).await? {
+                    let bootnode_multiaddr = node.multiaddr();
+
+                    bootnodes_addr.push(bootnode_multiaddr.to_string());
+                    ctx_para.nodes_by_name[node.name().to_owned()] = serde_json::to_value(&node)?;
+                    running_nodes.push(node);
+                }
             }
 
             if let Some(para_chain_spec) = para.chain_spec.as_ref() {
@@ -314,16 +329,18 @@ where
             ctx_para.bootnodes_addr = &bootnodes_addr;
 
             // Spawn the rest of the nodes
-            let spawning_tasks = collators.iter().map(|node| {
-                spawner::spawn_node(node, parachain.files_to_inject.clone(), &ctx_para)
-            });
+            for chunk in collators.chunks(spawn_concurrency) {
+                let spawning_tasks = chunk.iter().map(|node| {
+                    spawner::spawn_node(node, parachain.files_to_inject.clone(), &ctx_para)
+                });
 
-            // join all the running nodes
-            running_nodes.extend_from_slice(
-                futures::future::try_join_all(spawning_tasks)
-                    .await?
-                    .as_slice(),
-            );
+                // join all the running nodes
+                running_nodes.extend_from_slice(
+                    futures::future::try_join_all(spawning_tasks)
+                        .await?
+                        .as_slice(),
+                );
+            }
 
             let running_para_id = parachain.para_id;
             network.add_para(parachain);
@@ -539,6 +556,49 @@ fn help_msg(cmd: &str) -> String {
     }
 }
 
+/// Allow to set the default concurrency through env var `ZOMBIE_SPAWN_CONCURRENCY`
+fn spawn_concurrency_from_env() -> Option<usize> {
+    if let Ok(concurrency) = env::var("ZOMBIE_SPAWN_CONCURRENCY") {
+        concurrency.parse::<usize>().ok()
+    } else {
+        None
+    }
+}
+
+fn calculate_concurrency(spec: &NetworkSpec) -> Result<(usize, bool), anyhow::Error> {
+    let desired_spawn_concurrency = match (
+        spawn_concurrency_from_env(),
+        spec.global_settings.spawn_concurrency(),
+    ) {
+        (Some(n), _) => Some(n),
+        (None, Some(n)) => Some(n),
+        _ => None,
+    };
+
+    let (spawn_concurrency, limited_by_tokens) =
+        if let Some(spawn_concurrency) = desired_spawn_concurrency {
+            if spawn_concurrency == 1 {
+                (1, false)
+            } else {
+                if has_tokens(&serde_json::to_string(spec)?) {
+                    (1, true)
+                } else {
+                    (spawn_concurrency, false)
+                }
+            }
+        } else {
+            // not set
+            if has_tokens(&serde_json::to_string(spec)?) {
+                (1, true)
+            } else {
+                // use 100 as max concurrency, we can set a max by provider later
+                (100, false)
+            }
+        };
+
+    Ok((spawn_concurrency, limited_by_tokens))
+}
+
 // TODO: get the fs from `DynNamespace` will make this not needed
 // but the FileSystem trait isn't object-safe so we can't pass around
 // as `dyn FileSystem`. We can refactor or using some `erase` techniques
@@ -637,9 +697,25 @@ pub use pjs_helper::PjsResult;
 
 #[cfg(test)]
 mod tests {
-    use configuration::NetworkConfigBuilder;
+    use std::sync::{Mutex, MutexGuard};
+
+    use configuration::{GlobalSettingsBuilder, NetworkConfigBuilder};
 
     use super::*;
+
+    // mutex for test that use env
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+    const ENV_KEY: &str = "ZOMBIE_SPAWN_CONCURRENCY";
+
+    fn get_lock_with_env(concurrency: Option<u32>) -> MutexGuard<'static, ()> {
+        let guard = ENV_MUTEX.lock().unwrap();
+        if let Some(value) = concurrency {
+            env::set_var(ENV_KEY, value.to_string());
+        } else {
+            env::remove_var(ENV_KEY);
+        }
+        guard
+    }
 
     fn generate(
         with_image: bool,
@@ -732,5 +808,74 @@ mod tests {
         let valid = validate_spec_with_provider_capabilities(&spec, &caps);
         println!("{:?}", valid);
         assert!(valid.is_ok())
+    }
+
+    #[tokio::test]
+    async fn default_spawn_concurrency() {
+        let _guard = get_lock_with_env(None);
+        let network_config = generate(false, Some("cargo")).unwrap();
+        let spec = NetworkSpec::from_config(&network_config).await.unwrap();
+        let (concurrency, _) = calculate_concurrency(&spec).unwrap();
+        assert_eq!(concurrency, 100);
+    }
+
+    #[tokio::test]
+    async fn set_spawn_concurrency() {
+        let _guard = get_lock_with_env(None);
+        let network_config = generate(false, Some("cargo")).unwrap();
+        let mut spec = NetworkSpec::from_config(&network_config).await.unwrap();
+
+        let global_settings = GlobalSettingsBuilder::new()
+            .with_spawn_concurrency(4)
+            .build()
+            .unwrap();
+
+        spec.set_global_settings(global_settings);
+        let (concurrency, limited) = calculate_concurrency(&spec).unwrap();
+        assert_eq!(concurrency, 4);
+        assert!(!limited);
+    }
+
+    #[tokio::test]
+    async fn set_spawn_concurrency_but_limited() {
+        let _guard = get_lock_with_env(None);
+        let network_config = generate(false, Some("cargo")).unwrap();
+        let mut spec = NetworkSpec::from_config(&network_config).await.unwrap();
+
+        let global_settings = GlobalSettingsBuilder::new()
+            .with_spawn_concurrency(4)
+            .build()
+            .unwrap();
+
+        spec.set_global_settings(global_settings);
+        let node = spec.relaychain.nodes.first_mut().unwrap();
+        node.args
+            .push("--bootnodes {{ZOMBIE:bob:multiAddress')}}".into());
+        let (concurrency, limited) = calculate_concurrency(&spec).unwrap();
+        assert_eq!(concurrency, 1);
+        assert!(limited);
+    }
+
+    #[tokio::test]
+    async fn set_spawn_concurrency_from_env() {
+        let _guard = get_lock_with_env(Some(10));
+        let network_config = generate(false, Some("cargo")).unwrap();
+        let spec = NetworkSpec::from_config(&network_config).await.unwrap();
+        let (concurrency, limited) = calculate_concurrency(&spec).unwrap();
+        assert_eq!(concurrency, 10);
+        assert!(!limited);
+    }
+
+    #[tokio::test]
+    async fn set_spawn_concurrency_from_env_but_limited() {
+        let _guard = get_lock_with_env(Some(12));
+        let network_config = generate(false, Some("cargo")).unwrap();
+        let mut spec = NetworkSpec::from_config(&network_config).await.unwrap();
+        let node = spec.relaychain.nodes.first_mut().unwrap();
+        node.args
+            .push("--bootnodes {{ZOMBIE:bob:multiAddress')}}".into());
+        let (concurrency, limited) = calculate_concurrency(&spec).unwrap();
+        assert_eq!(concurrency, 1);
+        assert!(limited);
     }
 }

--- a/crates/orchestrator/src/network_spec.rs
+++ b/crates/orchestrator/src/network_spec.rs
@@ -6,7 +6,7 @@ use std::{
 use configuration::{GlobalSettings, HrmpChannelConfig, NetworkConfig};
 use futures::future::try_join_all;
 use provider::{DynNamespace, ProviderError, ProviderNamespace};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use support::{constants::THIS_IS_A_BUG, fs::FileSystem};
 use tracing::debug;
 
@@ -18,7 +18,7 @@ pub mod relaychain;
 
 use self::{node::NodeSpec, parachain::ParachainSpec, relaychain::RelaychainSpec};
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkSpec {
     /// Relaychain configuration.
     pub(crate) relaychain: RelaychainSpec,

--- a/crates/orchestrator/src/network_spec/parachain.rs
+++ b/crates/orchestrator/src/network_spec/parachain.rs
@@ -6,7 +6,7 @@ use configuration::{
     ParachainConfig, RegistrationStrategy,
 };
 use provider::DynNamespace;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use support::{fs::FileSystem, replacer::apply_replacements};
 use tracing::debug;
 
@@ -21,7 +21,7 @@ use crate::{
     ScopedFilesystem,
 };
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ParachainSpec {
     // `name` of the parachain (used in some corner cases)
     // name: Option<Chain>,

--- a/crates/orchestrator/src/network_spec/relaychain.rs
+++ b/crates/orchestrator/src/network_spec/relaychain.rs
@@ -7,7 +7,7 @@ use configuration::{
     },
     RelaychainConfig,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use support::replacer::apply_replacements;
 
 use super::node::NodeSpec;
@@ -18,7 +18,7 @@ use crate::{
 };
 
 /// A relaychain configuration spec
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RelaychainSpec {
     /// Chain to use (e.g. rococo-local).
     pub(crate) chain: Chain,

--- a/crates/support/src/replacer.rs
+++ b/crates/support/src/replacer.rs
@@ -21,6 +21,11 @@ lazy_static! {
     };
 }
 
+/// Return true if the text contains any TOKEN_PLACEHOLDER
+pub fn has_tokens(text: &str) -> bool {
+    TOKEN_PLACEHOLDER.is_match(text)
+}
+
 pub fn apply_replacements(text: &str, replacements: &HashMap<&str, &str>) -> String {
     let augmented_text = RE.replace_all(text, |caps: &Captures| {
         if let Some(replacements_value) = replacements.get(&caps[1]) {


### PR DESCRIPTION
Allow to set the concurrency for spawn nodes. _If_ we detect some reference between the nodes (using the `ZOMBIE:` token we override the concurrency to 1. 

Also, the concurrency can be set using this env var `ZOMBIE_SPAWN_CONCURRENCY` that take precedence over the config.

cc: @lrubasze 