### PR TITLE
add support for base_path/concurrency in cli

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,21 +1,33 @@
 use std::time::Duration;
 
 use clap::{Parser, Subcommand};
-use zombienet_sdk::{environment::Provider, NetworkConfig};
+use zombienet_sdk::{environment::Provider, GlobalSettingsBuilder, NetworkConfig};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
-struct Args {
+pub struct Args {
     #[command(subcommand)]
-    cmd: Commands,
+    pub cmd: Commands,
 }
 
 #[derive(Subcommand, Debug, Clone)]
-enum Commands {
+pub enum Commands {
     Spawn {
         config: String,
         #[arg(short, long, value_parser = clap::builder::PossibleValuesParser::new(["docker", "k8s", "native"]), default_value="docker")]
         provider: String,
+        #[arg(
+            short = 'd',
+            long = "dir",
+            help = "Directory path for placing the network files instead of random temp one (e.g. -d /home/user/my-zombienet)"
+        )]
+        base_path: Option<String>,
+        #[arg(
+            short = 'c',
+            long = "spawn-concurrency",
+            help = "Number of concurrent spawning process to launch"
+        )]
+        spawn_concurrency: Option<usize>,
     },
 }
 
@@ -25,11 +37,17 @@ async fn main() {
 
     let args = Args::parse();
 
-    let (config, provider) = match args.cmd {
-        Commands::Spawn { config, provider } => (config, provider),
+    let (config, provider, base_path, spawn_concurrency) = match args.cmd {
+        Commands::Spawn {
+            config,
+            provider,
+            base_path,
+            spawn_concurrency,
+        } => (config, provider, base_path, spawn_concurrency),
     };
 
-    let config = NetworkConfig::load_from_toml(&config).unwrap();
+    let config = network_config(&config, base_path, spawn_concurrency);
+
     let provider: Provider = provider.into();
     let spawn_fn = provider.get_spawn_fn();
     let _n = spawn_fn(config).await.unwrap();
@@ -38,5 +56,107 @@ async fn main() {
 
     loop {
         tokio::time::sleep(Duration::from_secs(60)).await;
+    }
+}
+
+pub fn network_config(
+    config: &str,
+    base_path: Option<String>,
+    concurrency: Option<usize>,
+) -> NetworkConfig {
+    let network_config = NetworkConfig::load_from_toml(&config).unwrap();
+
+    // nothing to override
+    if base_path.is_none() && concurrency.is_none() {
+        return network_config;
+    }
+
+    let current_settings = network_config.global_settings();
+    let bootnodes_addresses: Vec<String> = current_settings
+        .bootnodes_addresses()
+        .iter()
+        .map(|x| x.to_string())
+        .collect();
+
+    let settings_builder = GlobalSettingsBuilder::new()
+        .with_bootnodes_addresses(bootnodes_addresses.iter().map(|x| x.as_str()).collect())
+        .with_network_spawn_timeout(current_settings.network_spawn_timeout())
+        .with_node_spawn_timeout(current_settings.node_spawn_timeout());
+
+    let settings_builder = if let Some(local_ip) = current_settings.local_ip() {
+        settings_builder.with_local_ip(local_ip.to_string().as_str())
+    } else {
+        settings_builder
+    };
+
+    // overrides if needed
+    let settings_builder = if let Some(base_path) = base_path {
+        settings_builder.with_base_dir(base_path)
+    } else {
+        // check if is already defined
+        if let Some(base_path) = current_settings.base_dir() {
+            settings_builder.with_base_dir(base_path)
+        } else {
+            settings_builder
+        }
+    };
+
+    let settings_builder = if let Some(concurrency) = concurrency {
+        settings_builder.with_spawn_concurrency(concurrency)
+    } else {
+        // check if is already defined
+        if let Some(concurrency) = current_settings.spawn_concurrency() {
+            settings_builder.with_spawn_concurrency(concurrency)
+        } else {
+            settings_builder
+        }
+    };
+
+    let settings = settings_builder.build().unwrap();
+    NetworkConfig::load_from_toml_with_settings(&config, &settings).unwrap()
+}
+
+#[cfg(test)]
+mod test {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn works_without_any() {
+        let n = network_config("./testing/config.toml", None, None);
+        assert_eq!(
+            n.global_settings().base_dir(),
+            Some(PathBuf::from("/tmp/zombie-bite_1751850079747/spawn").as_path())
+        );
+        assert_eq!(n.global_settings().spawn_concurrency(), Some(4));
+    }
+
+    #[test]
+    fn works_with_base_path() {
+        let overrided = String::from("/tmp/overrided");
+        let expected = PathBuf::from("/tmp/overrided");
+        let n = network_config("./testing/config.toml", Some(overrided), None);
+        assert_eq!(n.global_settings().base_dir(), Some(expected.as_path()));
+        assert_eq!(n.global_settings().spawn_concurrency(), Some(4));
+    }
+
+    #[test]
+    fn works_with_concurrency() {
+        let n = network_config("./testing/config.toml", None, Some(1));
+        assert_eq!(
+            n.global_settings().base_dir(),
+            Some(PathBuf::from("/tmp/zombie-bite_1751850079747/spawn").as_path())
+        );
+        assert_eq!(n.global_settings().spawn_concurrency(), Some(1));
+    }
+
+    #[test]
+    fn works_with_both() {
+        let overrided = String::from("/tmp/overrided");
+        let expected = PathBuf::from("/tmp/overrided");
+        let n = network_config("./testing/config.toml", Some(overrided), Some(1));
+        assert_eq!(n.global_settings().base_dir(), Some(expected.as_path()));
+        assert_eq!(n.global_settings().spawn_concurrency(), Some(1));
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -64,7 +64,7 @@ pub fn network_config(
     base_path: Option<String>,
     concurrency: Option<usize>,
 ) -> NetworkConfig {
-    let network_config = NetworkConfig::load_from_toml(&config).unwrap();
+    let network_config = NetworkConfig::load_from_toml(config).unwrap();
 
     // nothing to override
     if base_path.is_none() && concurrency.is_none() {
@@ -113,7 +113,7 @@ pub fn network_config(
     };
 
     let settings = settings_builder.build().unwrap();
-    NetworkConfig::load_from_toml_with_settings(&config, &settings).unwrap()
+    NetworkConfig::load_from_toml_with_settings(config, &settings).unwrap()
 }
 
 #[cfg(test)]

--- a/crates/cli/testing/config.toml
+++ b/crates/cli/testing/config.toml
@@ -1,0 +1,23 @@
+[settings]
+timeout = 3600
+node_spawn_timeout = 300
+base_dir = "/tmp/zombie-bite_1751850079747/spawn"
+spawn_concurrency = 4
+
+[relaychain]
+chain = "polkadot"
+default_command = "doppelganger"
+
+
+[[relaychain.nodes]]
+name = "alice"
+
+[[relaychain.nodes]]
+name = "bob"
+
+[[parachains]]
+id = 1000
+chain = "asset-hub-polkadot"
+
+[[parachains.collators]]
+name = "collator"

--- a/crates/provider/src/native/namespace.rs
+++ b/crates/provider/src/native/namespace.rs
@@ -48,7 +48,7 @@ where
         let name = format!("{}{}", NAMESPACE_PREFIX, Uuid::new_v4());
         let base_dir = if let Some(custom_base_dir) = custom_base_dir {
             if !filesystem.exists(custom_base_dir).await {
-                filesystem.create_dir(custom_base_dir).await?;
+                filesystem.create_dir_all(custom_base_dir).await?;
             } else {
                 warn!(
                     "⚠️ Using and existing directory {} as base dir",


### PR DESCRIPTION
Add `-d` and `-c` options

```
Usage: zombie-cli spawn [OPTIONS] <CONFIG>

Arguments:
  <CONFIG>

Options:
  -p, --provider <PROVIDER>
          [default: docker] [possible values: docker, k8s, native]
  -d, --dir <BASE_PATH>
          Directory path for placing the network files instead of random temp one (e.g. -d /home/user/my-zombienet)
  -c, --spawn-concurrency <SPAWN_CONCURRENCY>
          Number of concurrent spawning process to launch
  -h, --help
          Print help
```