### PR TITLE
Node groups support

### DIFF
--- a/crates/configuration/src/network.rs
+++ b/crates/configuration/src/network.rs
@@ -134,7 +134,7 @@ impl NetworkConfig {
 
         let group_nodes: Vec<GroupNodeConfig> = network_config
             .relaychain()
-            .group_nodes()
+            .group_node_configs()
             .into_iter()
             .cloned()
             .collect();
@@ -204,8 +204,11 @@ impl NetworkConfig {
 
             let default_args: Vec<Arg> = para.default_args().into_iter().cloned().collect();
 
-            let group_collators: Vec<GroupNodeConfig> =
-                para.group_collators().into_iter().cloned().collect();
+            let group_collators: Vec<GroupNodeConfig> = para
+                .group_collators_configs()
+                .into_iter()
+                .cloned()
+                .collect();
 
             if let Some(group) = group_collators.iter().find(|n| n.count == 0) {
                 return Err(anyhow!(

--- a/crates/configuration/src/network.rs
+++ b/crates/configuration/src/network.rs
@@ -197,16 +197,17 @@ impl NetworkConfig {
 
             let default_args: Vec<Arg> = para.default_args().into_iter().cloned().collect();
 
-            let group_collators: Vec<GroupNodeConfig> = para.group_collators().into_iter().cloned().collect();
+            let group_collators: Vec<GroupNodeConfig> =
+                para.group_collators().into_iter().cloned().collect();
 
             let mut collators: Vec<NodeConfig> = para.collators.clone();
-            
+
             collators.extend(
                 group_collators
                     .into_iter()
                     .flat_map(|node| node.expand_group_configs()),
             );
-            
+
             for collator in collators.iter_mut() {
                 populate_collator_with_defaults(
                     collator,

--- a/crates/configuration/src/network.rs
+++ b/crates/configuration/src/network.rs
@@ -197,8 +197,16 @@ impl NetworkConfig {
 
             let default_args: Vec<Arg> = para.default_args().into_iter().cloned().collect();
 
-            let mut collators: Vec<NodeConfig> = para.collators.clone();
+            let group_collators: Vec<GroupNodeConfig> = para.group_collators().into_iter().cloned().collect();
 
+            let mut collators: Vec<NodeConfig> = para.collators.clone();
+            
+            collators.extend(
+                group_collators
+                    .into_iter()
+                    .flat_map(|node| node.expand_group_configs()),
+            );
+            
             for collator in collators.iter_mut() {
                 populate_collator_with_defaults(
                     collator,

--- a/crates/configuration/src/network.rs
+++ b/crates/configuration/src/network.rs
@@ -139,6 +139,13 @@ impl NetworkConfig {
             .cloned()
             .collect();
 
+        if let Some(group) = group_nodes.iter().find(|n| n.count == 0) {
+            return Err(anyhow!(
+                "Group node '{}' must have a count greater than 0.",
+                group.base_config.name()
+            ));
+        }
+
         let mut parachains: Vec<ParachainConfig> =
             network_config.parachains().into_iter().cloned().collect();
 
@@ -199,6 +206,13 @@ impl NetworkConfig {
 
             let group_collators: Vec<GroupNodeConfig> =
                 para.group_collators().into_iter().cloned().collect();
+
+            if let Some(group) = group_collators.iter().find(|n| n.count == 0) {
+                return Err(anyhow!(
+                    "Group node '{}' must have a count greater than 0.",
+                    group.base_config.name()
+                ));
+            }
 
             let mut collators: Vec<NodeConfig> = para.collators.clone();
 

--- a/crates/configuration/src/parachain.rs
+++ b/crates/configuration/src/parachain.rs
@@ -291,7 +291,7 @@ impl ParachainConfig {
     }
 
     /// The grouped collators of the parachain.
-    pub fn group_collators(&self) -> Vec<&GroupNodeConfig> {
+    pub fn group_collators_configs(&self) -> Vec<&GroupNodeConfig> {
         self.collator_groups.iter().collect::<Vec<_>>()
     }
 
@@ -1569,16 +1569,16 @@ mod tests {
 
         assert_eq!(parachain_config.id(), 1000);
         assert_eq!(parachain_config.collators().len(), 1);
-        assert_eq!(parachain_config.group_collators().len(), 2);
+        assert_eq!(parachain_config.group_collators_configs().len(), 2);
 
-        let group_collator1 = parachain_config.group_collators()[0].clone();
+        let group_collator1 = parachain_config.group_collators_configs()[0].clone();
         assert_eq!(group_collator1.count, 2);
         let base_config1 = group_collator1.base_config;
         assert_eq!(base_config1.name(), "collator_group1");
         assert_eq!(base_config1.command().unwrap().as_str(), "group_command1");
         assert!(base_config1.is_bootnode());
 
-        let group_collator2 = parachain_config.group_collators()[1].clone();
+        let group_collator2 = parachain_config.group_collators_configs()[1].clone();
         assert_eq!(group_collator2.count, 3);
         let base_config2 = group_collator2.base_config;
         assert_eq!(base_config2.name(), "collator_group2");

--- a/crates/configuration/src/parachain.rs
+++ b/crates/configuration/src/parachain.rs
@@ -865,6 +865,7 @@ impl<C: Context> ParachainConfigBuilder<WithId, C> {
         }
     }
 
+    /// Add a new collator group using a nested [`GroupNodeConfigBuilder`].
     pub fn with_collator_group(
         self,
         f: impl FnOnce(GroupNodeConfigBuilder<node::Initial>) -> GroupNodeConfigBuilder<node::Buildable>,
@@ -932,6 +933,7 @@ impl<C: Context> ParachainConfigBuilder<WithAtLeastOneCollator, C> {
         }
     }
 
+    /// Add a new collator group using a nested [`GroupNodeConfigBuilder`].
     pub fn with_collator_group(
         self,
         f: impl FnOnce(GroupNodeConfigBuilder<node::Initial>) -> GroupNodeConfigBuilder<node::Buildable>,

--- a/crates/configuration/src/parachain.rs
+++ b/crates/configuration/src/parachain.rs
@@ -12,7 +12,7 @@ use crate::{
     shared::{
         errors::{ConfigError, FieldError},
         helpers::{generate_unique_para_id, merge_errors, merge_errors_vecs},
-        node::{self, NodeConfig, NodeConfigBuilder},
+        node::{self, GroupNodeConfig, GroupNodeConfigBuilder, NodeConfig, NodeConfigBuilder},
         resources::{Resources, ResourcesBuilder},
         types::{
             Arg, AssetLocation, Chain, ChainDefaultContext, Command, Image, ValidationContext, U128,
@@ -160,6 +160,8 @@ pub struct ParachainConfig {
     // NOTE: if the file also contains multiple collators defined in
     // `[[parachain.collators]], the single configuration will be added to the bottom.
     pub(crate) collator: Option<NodeConfig>,
+    #[serde(skip_serializing_if = "std::vec::Vec::is_empty", default)]
+    pub(crate) collator_groups: Vec<GroupNodeConfig>,
 }
 
 impl ParachainConfig {
@@ -288,6 +290,11 @@ impl ParachainConfig {
         cols
     }
 
+    /// The grouped collators of the parachain.
+    pub fn group_collators(&self) -> Vec<&GroupNodeConfig> {
+        self.collator_groups.iter().collect::<Vec<_>>()
+    }
+
     /// The location of a wasm runtime to override in the chain-spec.
     pub fn wasm_override(&self) -> Option<&AssetLocation> {
         self.wasm_override.as_ref()
@@ -353,6 +360,7 @@ impl<C: Context> Default for ParachainConfigBuilder<Initial, C> {
                 no_default_bootnodes: false,
                 collators: vec![],
                 collator: None,
+                collator_groups: vec![],
             },
             validation_context: Default::default(),
             errors: vec![],
@@ -856,6 +864,38 @@ impl<C: Context> ParachainConfigBuilder<WithId, C> {
             ),
         }
     }
+
+    pub fn with_collator_group(
+        self,
+        f: impl FnOnce(GroupNodeConfigBuilder<node::Initial>) -> GroupNodeConfigBuilder<node::Buildable>,
+    ) -> Self {
+        match f(GroupNodeConfigBuilder::new(
+            self.default_chain_context(),
+            self.validation_context.clone(),
+        ))
+        .build()
+        {
+            Ok(group) => Self::transition(
+                ParachainConfig {
+                    collator_groups: [self.config.collator_groups, vec![group]].concat(),
+                    ..self.config
+                },
+                self.validation_context,
+                self.errors,
+            ),
+            Err((name, errors)) => Self::transition(
+                self.config,
+                self.validation_context,
+                merge_errors_vecs(
+                    self.errors,
+                    errors
+                        .into_iter()
+                        .map(|error| ConfigError::Collator(name.clone(), error).into())
+                        .collect::<Vec<_>>(),
+                ),
+            ),
+        }
+    }
 }
 
 impl<C: Context> ParachainConfigBuilder<WithAtLeastOneCollator, C> {
@@ -873,6 +913,38 @@ impl<C: Context> ParachainConfigBuilder<WithAtLeastOneCollator, C> {
             Ok(collator) => Self::transition(
                 ParachainConfig {
                     collators: [self.config.collators, vec![collator]].concat(),
+                    ..self.config
+                },
+                self.validation_context,
+                self.errors,
+            ),
+            Err((name, errors)) => Self::transition(
+                self.config,
+                self.validation_context,
+                merge_errors_vecs(
+                    self.errors,
+                    errors
+                        .into_iter()
+                        .map(|error| ConfigError::Collator(name.clone(), error).into())
+                        .collect::<Vec<_>>(),
+                ),
+            ),
+        }
+    }
+
+    pub fn with_collator_group(
+        self,
+        f: impl FnOnce(GroupNodeConfigBuilder<node::Initial>) -> GroupNodeConfigBuilder<node::Buildable>,
+    ) -> Self {
+        match f(GroupNodeConfigBuilder::new(
+            self.default_chain_context(),
+            self.validation_context.clone(),
+        ))
+        .build()
+        {
+            Ok(group) => Self::transition(
+                ParachainConfig {
+                    collator_groups: [self.config.collator_groups, vec![group]].concat(),
                     ..self.config
                 },
                 self.validation_context,
@@ -1459,5 +1531,58 @@ mod tests {
 
         assert_eq!(config.chain_spec_command(), Some(CMD_TPL));
         assert!(config.chain_spec_command_is_local());
+    }
+
+    #[test]
+    fn parachain_with_group_config_builder_should_succeeds_and_returns_a_new_parachain_config() {
+        let parachain_config = ParachainConfigBuilder::new(Default::default())
+            .with_id(1000)
+            .with_chain("mychainname")
+            .with_registration_strategy(RegistrationStrategy::UsingExtrinsic)
+            .onboard_as_parachain(false)
+            .with_initial_balance(100_000_042)
+            .with_default_image("myrepo:myimage")
+            .with_default_command("default_command")
+            .without_default_bootnodes()
+            .with_collator(|collator| {
+                collator
+                    .with_name("collator1")
+                    .with_command("command1")
+                    .bootnode(true)
+            })
+            .with_collator_group(|group| {
+                group.with_count(2).with_base_node(|base| {
+                    base.with_name("collator_group1")
+                        .with_command("group_command1")
+                        .bootnode(true)
+                })
+            })
+            .with_collator_group(|group| {
+                group.with_count(3).with_base_node(|base| {
+                    base.with_name("collator_group2")
+                        .with_command("group_command2")
+                        .bootnode(false)
+                })
+            })
+            .build()
+            .unwrap();
+
+        assert_eq!(parachain_config.id(), 1000);
+        assert_eq!(parachain_config.collators().len(), 1);
+        assert_eq!(parachain_config.group_collators().len(), 2);
+
+        let group_collator1 = parachain_config.group_collators()[0].clone();
+        assert_eq!(group_collator1.count, 2);
+        let base_config1 = group_collator1.base_config;
+        assert_eq!(base_config1.name(), "collator_group1");
+        assert_eq!(base_config1.command().unwrap().as_str(), "group_command1");
+        assert!(base_config1.is_bootnode());
+
+        let group_collator2 = parachain_config.group_collators()[1].clone();
+        assert_eq!(group_collator2.count, 3);
+        let base_config2 = group_collator2.base_config;
+        assert_eq!(base_config2.name(), "collator_group2");
+        assert_eq!(base_config2.command().unwrap().as_str(), "group_command2");
+        assert!(!base_config2.is_bootnode());
     }
 }

--- a/crates/configuration/src/relaychain.rs
+++ b/crates/configuration/src/relaychain.rs
@@ -125,7 +125,7 @@ impl RelaychainConfig {
         self.nodes.iter().collect::<Vec<&NodeConfig>>()
     }
 
-    pub fn group_nodes(&self) -> Vec<&GroupNodeConfig> {
+    pub fn group_node_configs(&self) -> Vec<&GroupNodeConfig> {
         self.node_groups.iter().collect::<Vec<&GroupNodeConfig>>()
     }
 
@@ -855,13 +855,13 @@ mod tests {
 
         assert_eq!(relaychain_config.chain().as_str(), "chain");
         assert_eq!(relaychain_config.nodes().len(), 1);
-        assert_eq!(relaychain_config.group_nodes().len(), 1);
-        assert_eq!(relaychain_config.group_nodes().first().unwrap().count, 2);
+        assert_eq!(relaychain_config.group_node_configs().len(), 1);
+        assert_eq!(relaychain_config.group_node_configs().first().unwrap().count, 2);
         let &node = relaychain_config.nodes().first().unwrap();
         assert_eq!(node.name(), "node");
         assert_eq!(node.command().unwrap().as_str(), "node_command");
 
-        let group_nodes = relaychain_config.group_nodes();
+        let group_nodes = relaychain_config.group_node_configs();
         let group_base_node = group_nodes.first().unwrap();
         assert_eq!(group_base_node.base_config.name(), "group_node");
         assert_eq!(

--- a/crates/configuration/src/relaychain.rs
+++ b/crates/configuration/src/relaychain.rs
@@ -856,7 +856,14 @@ mod tests {
         assert_eq!(relaychain_config.chain().as_str(), "chain");
         assert_eq!(relaychain_config.nodes().len(), 1);
         assert_eq!(relaychain_config.group_node_configs().len(), 1);
-        assert_eq!(relaychain_config.group_node_configs().first().unwrap().count, 2);
+        assert_eq!(
+            relaychain_config
+                .group_node_configs()
+                .first()
+                .unwrap()
+                .count,
+            2
+        );
         let &node = relaychain_config.nodes().first().unwrap();
         assert_eq!(node.name(), "node");
         assert_eq!(node.command().unwrap().as_str(), "node_command");

--- a/crates/configuration/src/relaychain.rs
+++ b/crates/configuration/src/relaychain.rs
@@ -520,6 +520,7 @@ impl RelaychainConfigBuilder<WithAtLeastOneNode> {
         }
     }
 
+    /// Add a new group node using a nested [`GroupNodeConfigBuilder`].
     pub fn with_group(
         self,
         f: impl FnOnce(GroupNodeConfigBuilder<node::Initial>) -> GroupNodeConfigBuilder<node::Buildable>,

--- a/crates/configuration/src/relaychain.rs
+++ b/crates/configuration/src/relaychain.rs
@@ -125,6 +125,7 @@ impl RelaychainConfig {
         self.nodes.iter().collect::<Vec<&NodeConfig>>()
     }
 
+    /// The group nodes of the relay chain.
     pub fn group_node_configs(&self) -> Vec<&GroupNodeConfig> {
         self.node_groups.iter().collect::<Vec<&GroupNodeConfig>>()
     }
@@ -453,7 +454,8 @@ impl RelaychainConfigBuilder<WithChain> {
         }
     }
 
-    pub fn with_group(
+    /// Add a new group node using a nested [`GroupNodeConfigBuilder`].
+    pub fn with_node_group(
         self,
         f: impl FnOnce(GroupNodeConfigBuilder<node::Initial>) -> GroupNodeConfigBuilder<node::Buildable>,
     ) -> RelaychainConfigBuilder<WithAtLeastOneNode> {
@@ -521,7 +523,7 @@ impl RelaychainConfigBuilder<WithAtLeastOneNode> {
     }
 
     /// Add a new group node using a nested [`GroupNodeConfigBuilder`].
-    pub fn with_group(
+    pub fn with_node_group(
         self,
         f: impl FnOnce(GroupNodeConfigBuilder<node::Initial>) -> GroupNodeConfigBuilder<node::Buildable>,
     ) -> Self {
@@ -842,7 +844,7 @@ mod tests {
                     .with_command("node_command")
                     .validator(true)
             })
-            .with_group(|group| {
+            .with_node_group(|group| {
                 group.with_count(2).with_base_node(|base| {
                     base.with_name("group_node")
                         .with_command("some_command")
@@ -892,7 +894,7 @@ mod tests {
                     .with_command("node_command")
                     .validator(true)
             })
-            .with_group(|group| {
+            .with_node_group(|group| {
                 group.with_count(0).with_base_node(|base| {
                     base.with_name("group_node")
                         .with_command("some_command")

--- a/crates/configuration/src/relaychain.rs
+++ b/crates/configuration/src/relaychain.rs
@@ -874,4 +874,36 @@ mod tests {
         );
         assert!(group_base_node.base_config.is_validator());
     }
+
+    #[test]
+    fn relaychain_with_group_count_0_config_should_fail() {
+        let relaychain_config = RelaychainConfigBuilder::new(Default::default())
+            .with_chain("chain")
+            .with_default_command("command")
+            .with_node(|node| {
+                node.with_name("node")
+                    .with_command("node_command")
+                    .validator(true)
+            })
+            .with_group(|group| {
+                group.with_count(0).with_base_node(|base| {
+                    base.with_name("group_node")
+                        .with_command("some_command")
+                        .with_image("repo:image")
+                        .validator(true)
+                })
+            })
+            .build();
+
+        let errors: Vec<anyhow::Error> = match relaychain_config {
+            Ok(_) => vec![],
+            Err(errs) => errs,
+        };
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(
+            errors.first().unwrap().to_string(),
+            "relaychain.nodes['group_node'].Count cannot be zero"
+        );
+    }
 }

--- a/crates/configuration/src/shared/node.rs
+++ b/crates/configuration/src/shared/node.rs
@@ -182,6 +182,10 @@ impl GroupNodeConfig {
             .take(self.count)
             .collect()
     }
+
+    pub fn base_node_name(&self) -> String {
+        self.base_config.name.clone()
+    }
 }
 
 impl Serialize for GroupNodeConfig {

--- a/crates/configuration/src/shared/node.rs
+++ b/crates/configuration/src/shared/node.rs
@@ -734,7 +734,7 @@ impl GroupNodeConfigBuilder<Initial> {
         }
     }
 
-    // Set the base node config using a closure.
+    /// Set the base node config using a closure.
     pub fn with_base_node(
         mut self,
         f: impl FnOnce(NodeConfigBuilder<Initial>) -> NodeConfigBuilder<Buildable>,

--- a/crates/configuration/src/shared/node.rs
+++ b/crates/configuration/src/shared/node.rs
@@ -778,7 +778,7 @@ impl GroupNodeConfigBuilder<Buildable> {
         if self.count == 0 {
             return Err((
                 self.base_config.name().to_string(),
-                vec![anyhow::anyhow!("Count cannot be zero").into()],
+                vec![anyhow::anyhow!("Count cannot be zero")],
             ));
         }
 

--- a/crates/configuration/src/shared/node.rs
+++ b/crates/configuration/src/shared/node.rs
@@ -63,7 +63,7 @@ impl From<(&str, &str)> for EnvVar {
 }
 
 /// A node configuration, with fine-grained configuration options.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 pub struct NodeConfig {
     pub(crate) name: String,
     pub(crate) image: Option<Image>,
@@ -164,6 +164,34 @@ impl Serialize for NodeConfig {
         }
 
         state.skip_field("chain_context")?;
+        state.end()
+    }
+}
+
+/// A group of nodes configuration
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct GroupNodeConfig {
+    #[serde(flatten)]
+    pub(crate) base_config: NodeConfig,
+    pub(crate) count: usize,
+}
+
+impl GroupNodeConfig {
+    pub fn expand_group_configs(&self) -> Vec<NodeConfig> {
+        std::iter::repeat(self.base_config.clone())
+            .take(self.count)
+            .collect()
+    }
+}
+
+impl Serialize for GroupNodeConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("GroupNodeConfig", 18)?;
+        state.serialize_field("NodeConfig", &self.base_config)?;
+        state.serialize_field("count", &self.count)?;
         state.end()
     }
 }
@@ -670,6 +698,93 @@ impl NodeConfigBuilder<Buildable> {
     }
 }
 
+/// A group node configuration builder, used to build a [`GroupNodeConfig`] declaratively with fields validation.
+pub struct GroupNodeConfigBuilder<S> {
+    base_config: NodeConfig,
+    count: usize,
+    validation_context: Rc<RefCell<ValidationContext>>,
+    errors: Vec<anyhow::Error>,
+    _state: PhantomData<S>,
+}
+
+impl GroupNodeConfigBuilder<Initial> {
+    pub fn new(
+        chain_context: ChainDefaultContext,
+        validation_context: Rc<RefCell<ValidationContext>>,
+    ) -> Self {
+        let (errors, base_config) = match NodeConfigBuilder::new(
+            chain_context.clone(),
+            validation_context.clone(),
+        )
+        .with_name(" ") // placeholder
+        .build()
+        {
+            Ok(base_config) => (vec![], base_config),
+            Err((_name, errors)) => (errors, NodeConfig::default()),
+        };
+
+        Self {
+            base_config,
+            count: 1,
+            validation_context,
+            errors,
+            _state: PhantomData,
+        }
+    }
+
+    // Set the base node config using a closure.
+    pub fn with_base_node(
+        mut self,
+        f: impl FnOnce(NodeConfigBuilder<Initial>) -> NodeConfigBuilder<Buildable>,
+    ) -> GroupNodeConfigBuilder<Buildable> {
+        match f(NodeConfigBuilder::new(
+            ChainDefaultContext::default(),
+            self.validation_context.clone(),
+        ))
+        .build()
+        {
+            Ok(node) => {
+                self.base_config = node;
+                GroupNodeConfigBuilder {
+                    base_config: self.base_config,
+                    count: self.count,
+                    validation_context: self.validation_context,
+                    errors: self.errors,
+                    _state: PhantomData,
+                }
+            },
+            Err((_name, errors)) => {
+                self.errors.extend(errors);
+                GroupNodeConfigBuilder {
+                    base_config: self.base_config,
+                    count: self.count,
+                    validation_context: self.validation_context,
+                    errors: self.errors,
+                    _state: PhantomData,
+                }
+            },
+        }
+    }
+
+    /// Set the number of nodes in the group.
+    pub fn with_count(mut self, count: usize) -> Self {
+        self.count = count;
+        self
+    }
+}
+
+impl GroupNodeConfigBuilder<Buildable> {
+    pub fn build(self) -> Result<GroupNodeConfig, (String, Vec<anyhow::Error>)> {
+        if !self.errors.is_empty() {
+            return Err((self.base_config.name().to_string(), self.errors));
+        }
+        Ok(GroupNodeConfig {
+            base_config: self.base_config,
+            count: self.count,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
@@ -1021,5 +1136,56 @@ mod tests {
 
         assert_eq!(errors.len(), 1);
         assert_eq!(errors.first().unwrap().to_string(), "name: can't be empty");
+    }
+
+    #[test]
+    fn group_default_base_node() {
+        let validation_context = Rc::new(RefCell::new(ValidationContext::default()));
+
+        let group_config =
+            GroupNodeConfigBuilder::new(ChainDefaultContext::default(), validation_context.clone())
+                .with_base_node(|node| node.with_name("validator"))
+                .build()
+                .unwrap();
+
+        // Check group config
+        assert_eq!(group_config.count, 1);
+        assert_eq!(group_config.base_config.name(), "validator");
+    }
+
+    #[test]
+    fn group_custom_base_node() {
+        let validation_context = Rc::new(RefCell::new(ValidationContext::default()));
+        let node_config =
+            NodeConfigBuilder::new(ChainDefaultContext::default(), validation_context.clone())
+                .with_name("node")
+                .with_command("some_command")
+                .with_image("repo:image")
+                .validator(true)
+                .invulnerable(true)
+                .bootnode(true);
+
+        let group_config =
+            GroupNodeConfigBuilder::new(ChainDefaultContext::default(), validation_context.clone())
+                .with_count(5)
+                .with_base_node(|_node| node_config)
+                .build()
+                .unwrap();
+
+        // Check group config
+        assert_eq!(group_config.count, 5);
+
+        assert_eq!(group_config.base_config.name(), "node");
+        assert_eq!(
+            group_config.base_config.command().unwrap().as_str(),
+            "some_command"
+        );
+        assert_eq!(
+            group_config.base_config.image().unwrap().as_str(),
+            "repo:image"
+        );
+        assert!(group_config.base_config.is_validator());
+        assert!(group_config.base_config.is_invulnerable());
+        assert!(group_config.base_config.is_bootnode());
     }
 }

--- a/crates/configuration/src/shared/node.rs
+++ b/crates/configuration/src/shared/node.rs
@@ -177,6 +177,8 @@ pub struct GroupNodeConfig {
 }
 
 impl GroupNodeConfig {
+    /// Expands the group into individual node configs.
+    /// Each node will have the same base configuration.
     pub fn expand_group_configs(&self) -> Vec<NodeConfig> {
         std::iter::repeat(self.base_config.clone())
             .take(self.count)

--- a/crates/configuration/src/shared/node.rs
+++ b/crates/configuration/src/shared/node.rs
@@ -182,10 +182,6 @@ impl GroupNodeConfig {
             .take(self.count)
             .collect()
     }
-
-    pub fn base_node_name(&self) -> String {
-        self.base_config.name.clone()
-    }
 }
 
 impl Serialize for GroupNodeConfig {

--- a/crates/configuration/src/shared/node.rs
+++ b/crates/configuration/src/shared/node.rs
@@ -775,9 +775,17 @@ impl GroupNodeConfigBuilder<Initial> {
 
 impl GroupNodeConfigBuilder<Buildable> {
     pub fn build(self) -> Result<GroupNodeConfig, (String, Vec<anyhow::Error>)> {
+        if self.count == 0 {
+            return Err((
+                self.base_config.name().to_string(),
+                vec![anyhow::anyhow!("Count cannot be zero").into()],
+            ));
+        }
+
         if !self.errors.is_empty() {
             return Err((self.base_config.name().to_string(), self.errors));
         }
+
         Ok(GroupNodeConfig {
             base_config: self.base_config,
             count: self.count,

--- a/crates/examples/examples/0002-simple-group-nodes.toml
+++ b/crates/examples/examples/0002-simple-group-nodes.toml
@@ -2,19 +2,17 @@
 timeout = 1000
 
 [relaychain]
-default_image = "{{ZOMBIENET_INTEGRATION_TEST_IMAGE}}"
+default_image = "docker.io/parity/polkadot:latest"
 chain = "rococo-local"
 default_command = "polkadot"
 
     [[relaychain.node_groups]]
     name = "group1"
-    image = "docker.io/parity/polkadot:latest"
     validator = true
     count = 3
 
     [[relaychain.node_groups]]
     name = "group2"
-    image = "docker.io/parity/polkadot:latest"
     validator = true
     count = 2
     
@@ -23,18 +21,17 @@ default_command = "polkadot"
 
 [[parachains]]
 id = 100
-addToGenesis = false
 cumulus_based = false
 
   [[parachains.collators]]
   name = "collator01"
-  image = "{{COL_IMAGE}}"
+  image = "paritypr/colander:master-32142045"
   command = "adder-collator"
   args = [ "-lruntime=debug,parachain=trace" ]
 
   [[parachains.collator_groups]]
   name = "collator_group"
-  image = "{{COL_IMAGE}}"
+  image = "paritypr/colander:master-32142045"
   command = "adder-collator"
   args = [ "-lruntime=debug,parachain=trace" ]
   count = 2

--- a/crates/examples/examples/0002-simple-group-nodes.toml
+++ b/crates/examples/examples/0002-simple-group-nodes.toml
@@ -1,34 +1,25 @@
 [settings]
 timeout = 1000
 
-[relaychain.runtime_genesis_patch.configuration.config]
-max_validators_per_core = 2
-needed_approvals = 2
-group_rotation_frequency = 10
-
-
 [relaychain]
 default_image = "{{ZOMBIENET_INTEGRATION_TEST_IMAGE}}"
 chain = "rococo-local"
-command = "polkadot"
+default_command = "polkadot"
 
     [[relaychain.node_groups]]
     name = "group1"
     image = "docker.io/parity/polkadot:latest"
-    command = "polkadot"
     validator = true
     count = 3
 
     [[relaychain.node_groups]]
     name = "group2"
     image = "docker.io/parity/polkadot:latest"
-    command = "polkadot"
     validator = true
     count = 2
     
 [[relaychain.nodes]]
   name = "alice"
-  args = [ "--alice", "-lruntime=debug,parachain=trace" ]
 
 [[parachains]]
 id = 100
@@ -47,8 +38,3 @@ cumulus_based = false
   command = "adder-collator"
   args = [ "-lruntime=debug,parachain=trace" ]
   count = 2
-
-[types.Header]
-number = "u64"
-parent_hash = "Hash"
-post_state = "Hash"

--- a/crates/examples/examples/0002-simple-group-nodes.toml
+++ b/crates/examples/examples/0002-simple-group-nodes.toml
@@ -1,0 +1,47 @@
+[settings]
+timeout = 1000
+
+[relaychain.runtime_genesis_patch.configuration.config]
+max_validators_per_core = 2
+needed_approvals = 2
+group_rotation_frequency = 10
+
+
+[relaychain]
+default_image = "{{ZOMBIENET_INTEGRATION_TEST_IMAGE}}"
+chain = "rococo-local"
+command = "polkadot"
+
+    [[relaychain.node_groups]]
+    name = "group1"
+    image = "docker.io/parity/polkadot:latest"
+    command = "polkadot"
+    validator = true
+    count = 3
+
+    [[relaychain.node_groups]]
+    name = "group2"
+    image = "docker.io/parity/polkadot:latest"
+    command = "polkadot"
+    validator = true
+    count = 2
+    
+[[relaychain.nodes]]
+  name = "alice"
+  args = [ "--alice", "-lruntime=debug,parachain=trace" ]
+
+[[parachains]]
+id = 100
+addToGenesis = false
+cumulus_based = false
+
+  [[parachains.collators]]
+  name = "collator01"
+  image = "{{COL_IMAGE}}"
+  command = "adder-collator"
+  args = [ "-lruntime=debug,parachain=trace" ]
+
+[types.Header]
+number = "u64"
+parent_hash = "Hash"
+post_state = "Hash"

--- a/crates/examples/examples/0002-simple-group-nodes.toml
+++ b/crates/examples/examples/0002-simple-group-nodes.toml
@@ -41,6 +41,13 @@ cumulus_based = false
   command = "adder-collator"
   args = [ "-lruntime=debug,parachain=trace" ]
 
+  [[parachains.collator_groups]]
+  name = "collator_group"
+  image = "{{COL_IMAGE}}"
+  command = "adder-collator"
+  args = [ "-lruntime=debug,parachain=trace" ]
+  count = 2
+
 [types.Header]
 number = "u64"
 parent_hash = "Hash"

--- a/crates/examples/examples/add_para.rs
+++ b/crates/examples/examples/add_para.rs
@@ -15,15 +15,14 @@ async fn main() -> Result<(), anyhow::Error> {
                 .with_node(|node| node.with_name("bob"))
         })
         .with_parachain(|p| {
-            p.with_id(2000)
-                .cumulus_based(true)
-                .with_collator(|n|
+            p.with_id(2000).cumulus_based(true).with_collator(
+                |n| {
                     n.with_name("collator")
                     // TODO: check how we can clean
                     .with_command("polkadot-parachain")
-                    // .with_command("test-parachain")
-                    // .with_image("docker.io/paritypr/test-parachain:c90f9713b5bc73a9620b2e72b226b4d11e018190")
-                )
+                }, // .with_command("test-parachain")
+                   // .with_image("docker.io/paritypr/test-parachain:c90f9713b5bc73a9620b2e72b226b4d11e018190")
+            )
         })
         .build()
         .unwrap()

--- a/crates/examples/examples/big_network_with_group_nodes.rs
+++ b/crates/examples/examples/big_network_with_group_nodes.rs
@@ -1,0 +1,48 @@
+use zombienet_sdk::{NetworkConfigBuilder, NetworkConfigExt};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+    let network = NetworkConfigBuilder::new()
+        .with_relaychain(|r| {
+            r.with_chain("rococo-local")
+                .with_default_command("polkadot")
+                .with_group(|g| {
+                    g.with_count(3)
+                        .with_base_node(|b| b.with_name("relay_group"))
+                })
+        })
+        .with_parachain(|p| {
+            p.with_id(100)
+                .cumulus_based(true)
+                .with_default_command("polkadot-parachain")
+                .with_collator_group(|g| {
+                    g.with_count(3)
+                        .with_base_node(|b| b.with_name("para_group"))
+                })
+                .with_collator_group(|f| {
+                    f.with_count(2)
+                        .with_base_node(|b| b.with_name("para_group-2"))
+                })
+        })
+        .build()
+        .unwrap()
+        .spawn_native()
+        .await?;
+
+    println!("🚀🚀🚀🚀 network deployed");
+
+    let nodes = network.relaychain().nodes();
+    nodes.iter().for_each(|node| {
+        println!("Relay node: {}", node.name());
+    });
+
+    let collators = network.parachains()[0].collators();
+    collators.iter().for_each(|collator| {
+        println!("Collator: {}", collator.name());
+    });
+
+    #[allow(clippy::empty_loop)]
+    loop {}
+
+}

--- a/crates/examples/examples/big_network_with_group_nodes.rs
+++ b/crates/examples/examples/big_network_with_group_nodes.rs
@@ -1,8 +1,16 @@
+use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 use zombienet_sdk::{NetworkConfigBuilder, NetworkConfigExt};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
     let network = NetworkConfigBuilder::new()
         .with_relaychain(|r| {
             r.with_chain("rococo-local")

--- a/crates/examples/examples/big_network_with_group_nodes.rs
+++ b/crates/examples/examples/big_network_with_group_nodes.rs
@@ -44,5 +44,4 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     #[allow(clippy::empty_loop)]
     loop {}
-
 }

--- a/crates/examples/examples/big_network_with_group_nodes.rs
+++ b/crates/examples/examples/big_network_with_group_nodes.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_relaychain(|r| {
             r.with_chain("rococo-local")
                 .with_default_command("polkadot")
-                .with_group(|g| {
+                .with_node_group(|g| {
                     g.with_count(3)
                         .with_base_node(|b| b.with_name("relay_group"))
                 })

--- a/crates/examples/examples/network_example_with_group_nodes.rs
+++ b/crates/examples/examples/network_example_with_group_nodes.rs
@@ -18,8 +18,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("Node: {}", node.name());
     });
 
+    let collators = network.parachains()[0].collators();
+    assert_eq!(collators.len(), 3);
+    collators.iter().for_each(|collator| {
+        println!("Collator: {}", collator.name());
+    });
+
     let client = network
-        .get_node("collator01")?
+        .get_node("collator_group-1")?
         .wait_client::<subxt::PolkadotConfig>()
         .await?;
     let mut blocks = client.blocks().subscribe_finalized().await?.take(3);

--- a/crates/examples/examples/network_example_with_group_nodes.rs
+++ b/crates/examples/examples/network_example_with_group_nodes.rs
@@ -1,9 +1,17 @@
 use futures::stream::StreamExt;
+use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 use zombienet_sdk::{subxt, NetworkConfig, NetworkConfigExt};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
     let network =
         NetworkConfig::load_from_toml("./crates/examples/examples/0002-simple-group-nodes.toml")
             .expect("errored?")

--- a/crates/examples/examples/network_example_with_group_nodes.rs
+++ b/crates/examples/examples/network_example_with_group_nodes.rs
@@ -1,0 +1,32 @@
+use futures::stream::StreamExt;
+use zombienet_sdk::{subxt, NetworkConfig, NetworkConfigExt};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+    let network =
+        NetworkConfig::load_from_toml("./crates/examples/examples/0002-simple-group-nodes.toml")
+            .expect("errored?")
+            .spawn_native()
+            .await?;
+
+    println!("🚀🚀🚀🚀 network deployed");
+
+    let nodes = network.relaychain().nodes();
+    assert_eq!(nodes.len(), 6);
+    nodes.iter().for_each(|node| {
+        println!("Node: {}", node.name());
+    });
+
+    let client = network
+        .get_node("collator01")?
+        .wait_client::<subxt::PolkadotConfig>()
+        .await?;
+    let mut blocks = client.blocks().subscribe_finalized().await?.take(3);
+
+    while let Some(block) = blocks.next().await {
+        println!("Block #{}", block?.header().number);
+    }
+
+    Ok(())
+}

--- a/crates/orchestrator/src/network_spec/parachain.rs
+++ b/crates/orchestrator/src/network_spec/parachain.rs
@@ -170,9 +170,9 @@ impl ParachainSpec {
         let mut nodes: Vec<NodeConfig> = config.collators().into_iter().cloned().collect();
         nodes.extend(
             config
-                .group_collators()
+                .group_collators_configs()
                 .into_iter()
-                .flat_map(|node| node.expand_group_configs()),
+                .flat_map(|node_group| node_group.expand_group_configs()),
         );
 
         let mut names = HashSet::new();

--- a/crates/orchestrator/src/network_spec/parachain.rs
+++ b/crates/orchestrator/src/network_spec/parachain.rs
@@ -1,9 +1,12 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+};
 
 use configuration::{
-    shared::resources::Resources,
+    shared::{helpers::generate_unique_node_name_from_names, resources::Resources},
     types::{Arg, AssetLocation, Command, Image},
-    ParachainConfig, RegistrationStrategy,
+    NodeConfig, ParachainConfig, RegistrationStrategy,
 };
 use provider::DynNamespace;
 use serde::{Deserialize, Serialize};
@@ -163,13 +166,26 @@ impl ParachainSpec {
         // We want to track the errors for all the nodes and report them ones
         let mut errs: Vec<OrchestratorError> = Default::default();
         let mut collators: Vec<NodeSpec> = Default::default();
-        config.collators().iter().for_each(|node_config| {
-            match NodeSpec::from_config(node_config, &chain_context, true) {
-                Ok(node) => collators.push(node),
+
+        let mut nodes: Vec<NodeConfig> = config.collators().into_iter().cloned().collect();
+        nodes.extend(
+            config
+                .group_collators()
+                .into_iter()
+                .flat_map(|node| node.expand_group_configs()),
+        );
+
+        let mut names = HashSet::new();
+        for node_config in nodes {
+            match NodeSpec::from_config(&node_config, &chain_context, true) {
+                Ok(mut node) => {
+                    let unique_name = generate_unique_node_name_from_names(node.name, &mut names);
+                    node.name = unique_name;
+                    collators.push(node)
+                },
                 Err(err) => errs.push(err),
             }
-        });
-
+        }
         let genesis_state = if let Some(path) = config.genesis_state_path() {
             ParaArtifact::new(
                 ParaArtifactType::State,

--- a/crates/orchestrator/src/network_spec/relaychain.rs
+++ b/crates/orchestrator/src/network_spec/relaychain.rs
@@ -112,9 +112,9 @@ impl RelaychainSpec {
         let mut nodes: Vec<NodeConfig> = config.nodes().into_iter().cloned().collect();
         nodes.extend(
             config
-                .group_nodes()
+                .group_node_configs()
                 .into_iter()
-                .flat_map(|node| node.expand_group_configs()),
+                .flat_map(|node_group| node_group.expand_group_configs()),
         );
 
         let mut names = HashSet::new();


### PR DESCRIPTION
Implements #401 

Add support for grouping nodes with shared configuration
Implemented for both relaychain and parachain nodes.

Example: 
```toml
[relaychain]
    [[relaychain.node_groups]]
    name = "group1"
    image = "docker.io/parity/polkadot:latest"
    command = "polkadot"
    validator = true
    count = 3

    [[relaychain.node_groups]]
    name = "group2"
    image = "docker.io/parity/polkadot:latest"
    command = "polkadot"
    validator = true
    count = 2
    
[[relaychain.nodes]]
  name = "alice"
  args = [ "--alice", "-lruntime=debug,parachain=trace" ]

[[parachains]]
id = 100
addToGenesis = false
cumulus_based = false

  [[parachains.collators]]
  name = "collator01"
  image = "{{COL_IMAGE}}"
  command = "adder-collator"
  args = [ "-lruntime=debug,parachain=trace" ]

  [[parachains.collator_groups]]
  name = "collator_group"
  image = "{{COL_IMAGE}}"
  command = "adder-collator"
  args = [ "-lruntime=debug,parachain=trace" ]
  count = 2
```