### PR TITLE
Fix: Race in unit tests - Verify default spawn timeout before setting…

### DIFF
--- a/crates/configuration/src/utils.rs
+++ b/crates/configuration/src/utils.rs
@@ -50,14 +50,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_node_spawn_timeout_works_when_env_is_set() {
+    fn default_node_spawn_timeout_works_before_and_after_env_is_set() {
+        assert_eq!(default_node_spawn_timeout(), 600);
         env::set_var(ZOMBIE_NODE_SPAWN_TIMEOUT_SECONDS, "123");
         assert_eq!(default_node_spawn_timeout(), 123);
-    }
-
-    #[test]
-    fn default_node_spawn_timeout_falls_back_to_default_when_env_is_not_set() {
-        assert_eq!(default_node_spawn_timeout(), 600);
     }
 
     #[test]


### PR DESCRIPTION
If ```default_node_spawn_timeout_works_when_env_is_set``` is executed before ```default_node_spawn_timeout_falls_back_to_default_when_env_is_not_set``` it fails because the environment variable is already set.