### PR TITLE
Fix group nodes being expanded twice when loading network from config…

### DIFF
--- a/crates/configuration/src/network.rs
+++ b/crates/configuration/src/network.rs
@@ -160,12 +160,6 @@ impl NetworkConfig {
             )?;
         }
 
-        nodes.extend(
-            group_nodes
-                .into_iter()
-                .flat_map(|node| node.expand_group_configs()),
-        );
-
         // Keep track of node names to ensure uniqueness
         let mut names = HashSet::new();
 
@@ -218,12 +212,6 @@ impl NetworkConfig {
             }
 
             let mut collators: Vec<NodeConfig> = para.collators.clone();
-
-            collators.extend(
-                group_collators
-                    .into_iter()
-                    .flat_map(|node| node.expand_group_configs()),
-            );
 
             for collator in collators.iter_mut() {
                 populate_collator_with_defaults(

--- a/crates/examples/examples/big_network_with_group_nodes.rs
+++ b/crates/examples/examples/big_network_with_group_nodes.rs
@@ -41,11 +41,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("🚀🚀🚀🚀 network deployed");
 
     let nodes = network.relaychain().nodes();
+    assert_eq!(nodes.len(), 3);
     nodes.iter().for_each(|node| {
         println!("Relay node: {}", node.name());
     });
 
     let collators = network.parachains()[0].collators();
+    assert_eq!(collators.len(), 5);
     collators.iter().for_each(|collator| {
         println!("Collator: {}", collator.name());
     });


### PR DESCRIPTION
Previously, group nodes were expanded once during network config loading and a second time in the orchestrator, resulting in duplicate nodes, now are expanded only in orchestrator.