### PR TITLE
feat: add support for per-node log_path configuration

### DIFF
--- a/crates/configuration/src/shared/node.rs
+++ b/crates/configuration/src/shared/node.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, error::Error, fmt::Display, marker::PhantomData, rc::Rc};
+use std::{cell::RefCell, error::Error, fmt::Display, marker::PhantomData, path::PathBuf, rc::Rc};
 
 use multiaddr::Multiaddr;
 use serde::{ser::SerializeStruct, Deserialize, Serialize};
@@ -6,8 +6,8 @@ use serde::{ser::SerializeStruct, Deserialize, Serialize};
 use super::{
     errors::FieldError,
     helpers::{
-        ensure_port_unique, ensure_value_is_not_empty, generate_unique_node_name, merge_errors,
-        merge_errors_vecs,
+        ensure_port_unique, ensure_value_is_not_empty, generate_unique_node_name,
+        generate_unique_node_name_from_names, merge_errors, merge_errors_vecs,
     },
     macros::states,
     resources::ResourcesBuilder,
@@ -94,6 +94,7 @@ pub struct NodeConfig {
     #[serde(default)]
     // used to skip serialization of fields with defaults to avoid duplication
     pub(crate) chain_context: ChainDefaultContext,
+    pub(crate) node_log_path: Option<PathBuf>,
 }
 
 impl Serialize for NodeConfig {
@@ -163,6 +164,12 @@ impl Serialize for NodeConfig {
             state.serialize_field("db_snapshot", &self.db_snapshot)?;
         }
 
+        if self.node_log_path.is_none() {
+            state.skip_field("node_log_path")?;
+        } else {
+            state.serialize_field("node_log_path", &self.node_log_path)?;
+        }
+
         state.skip_field("chain_context")?;
         state.end()
     }
@@ -178,10 +185,29 @@ pub struct GroupNodeConfig {
 
 impl GroupNodeConfig {
     /// Expands the group into individual node configs.
-    /// Each node will have the same base configuration.
+    /// Each node will have the same base configuration, but with unique names and log paths.
     pub fn expand_group_configs(&self) -> Vec<NodeConfig> {
-        std::iter::repeat(self.base_config.clone())
-            .take(self.count)
+        let mut used_names = std::collections::HashSet::new();
+
+        (0..self.count)
+            .map(|_index| {
+                let mut node = self.base_config.clone();
+
+                let unique_name = generate_unique_node_name_from_names(node.name, &mut used_names);
+                node.name = unique_name;
+
+                // If base config has a log path, generate unique log path for each node
+                if let Some(ref base_log_path) = node.node_log_path {
+                    let unique_log_path = if let Some(parent) = base_log_path.parent() {
+                        parent.join(format!("{}.log", node.name))
+                    } else {
+                        PathBuf::from(format!("{}.log", node.name))
+                    };
+                    node.node_log_path = Some(unique_log_path);
+                }
+
+                node
+            })
             .collect()
     }
 }
@@ -293,6 +319,11 @@ impl NodeConfig {
     pub fn db_snapshot(&self) -> Option<&AssetLocation> {
         self.db_snapshot.as_ref()
     }
+
+    /// Node log path
+    pub fn node_log_path(&self) -> Option<&PathBuf> {
+        self.node_log_path.as_ref()
+    }
 }
 
 /// A node configuration builder, used to build a [`NodeConfig`] declaratively with fields validation.
@@ -326,6 +357,7 @@ impl Default for NodeConfigBuilder<Initial> {
                 p2p_cert_hash: None,
                 db_snapshot: None,
                 chain_context: Default::default(),
+                node_log_path: None,
             },
             validation_context: Default::default(),
             errors: vec![],
@@ -683,6 +715,18 @@ impl NodeConfigBuilder<Buildable> {
         Self::transition(
             NodeConfig {
                 db_snapshot: Some(location.into()),
+                ..self.config
+            },
+            self.validation_context,
+            self.errors,
+        )
+    }
+
+    /// Set the node log path that will be used to launch the node.
+    pub fn with_log_path(self, log_path: impl Into<PathBuf>) -> Self {
+        Self::transition(
+            NodeConfig {
+                node_log_path: Some(log_path.into()),
                 ..self.config
             },
             self.validation_context,

--- a/crates/examples/examples/big_network_with_group_nodes.rs
+++ b/crates/examples/examples/big_network_with_group_nodes.rs
@@ -25,12 +25,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .cumulus_based(true)
                 .with_default_command("polkadot-parachain")
                 .with_collator_group(|g| {
-                    g.with_count(3)
+                    g.with_count(2)
                         .with_base_node(|b| b.with_name("para_group"))
                 })
                 .with_collator_group(|f| {
-                    f.with_count(2)
-                        .with_base_node(|b| b.with_name("para_group-2"))
+                    f.with_count(3).with_base_node(|b| {
+                        b.with_name("para_group-2")
+                            .with_log_path("/tmp/para_group_2.log")
+                    })
                 })
         })
         .build()

--- a/crates/examples/examples/small_network_with_para.rs
+++ b/crates/examples/examples/small_network_with_para.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             r.with_chain("rococo-local")
                 .with_default_command("polkadot")
                 .with_validator(|node| node.with_name("alice"))
-                .with_validator(|node| node.with_name("bob"))
+                .with_validator(|node| node.with_name("bob").with_log_path("/tmp/bob.log"))
         })
         .with_parachain(|p| {
             p.with_id(100)

--- a/crates/orchestrator/src/network_spec/node.rs
+++ b/crates/orchestrator/src/network_spec/node.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use configuration::shared::{
     node::{EnvVar, NodeConfig},
     resources::Resources,
@@ -117,6 +119,9 @@ pub struct NodeSpec {
     pub(crate) full_node_p2p_port: Option<ParkedPort>,
     /// Prometheus port to use by full node if this is the case
     pub(crate) full_node_prometheus_port: Option<ParkedPort>,
+
+    /// Optionally specify a log path for the node
+    pub(crate) node_log_path: Option<PathBuf>,
 }
 
 impl NodeSpec {
@@ -205,6 +210,7 @@ impl NodeSpec {
             p2p_port: generators::generate_node_port(node_config.p2p_port())?,
             full_node_p2p_port,
             full_node_prometheus_port,
+            node_log_path: node_config.node_log_path().cloned(),
         })
     }
 
@@ -294,6 +300,7 @@ impl NodeSpec {
             p2p_port: generators::generate_node_port(options.p2p_port)?,
             full_node_p2p_port,
             full_node_prometheus_port,
+            node_log_path: None,
         })
     }
 

--- a/crates/orchestrator/src/spawner.rs
+++ b/crates/orchestrator/src/spawner.rs
@@ -195,7 +195,8 @@ where
         .injected_files(files_to_inject)
         .created_paths(created_paths)
         .db_snapshot(node.db_snapshot.clone())
-        .port_mapping(HashMap::from(ports));
+        .port_mapping(HashMap::from(ports))
+        .node_log_path(node.node_log_path.clone());
 
     let spawn_ops = if let Some(image) = node.image.as_ref() {
         spawn_ops.image(image.as_str())

--- a/crates/provider/src/native/namespace.rs
+++ b/crates/provider/src/native/namespace.rs
@@ -137,6 +137,7 @@ where
             created_paths: &options.created_paths,
             db_snapshot: options.db_snapshot.as_ref(),
             filesystem: &self.filesystem,
+            node_log_path: options.node_log_path.as_ref(),
         })
         .await?;
 

--- a/crates/provider/src/native/node.rs
+++ b/crates/provider/src/native/node.rs
@@ -53,6 +53,7 @@ where
     pub(super) created_paths: &'a [PathBuf],
     pub(super) db_snapshot: Option<&'a AssetLocation>,
     pub(super) filesystem: &'a FS,
+    pub(super) node_log_path: Option<&'a PathBuf>,
 }
 
 pub(super) struct NativeNode<FS>
@@ -97,7 +98,10 @@ where
         let data_dir = PathBuf::from(format!("{base_dir_raw}{NODE_DATA_DIR}"));
         let relay_data_dir = PathBuf::from(format!("{base_dir_raw}{NODE_RELAY_DATA_DIR}"));
         let scripts_dir = PathBuf::from(format!("{base_dir_raw}{NODE_SCRIPTS_DIR}"));
-        let log_path = base_dir.join(format!("{}.log", options.name));
+        let log_path = options
+            .node_log_path
+            .cloned()
+            .unwrap_or_else(|| base_dir.join(format!("{}.log", options.name)));
 
         trace!("creating dirs {:?}", config_dir);
         try_join!(
@@ -405,11 +409,7 @@ where
     }
 
     fn log_cmd(&self) -> String {
-        format!(
-            "tail -f {}/{}.log",
-            self.base_dir().to_string_lossy(),
-            self.name()
-        )
+        format!("tail -f {}", self.log_path().to_string_lossy())
     }
 
     fn path_in_node(&self, file: &Path) -> PathBuf {

--- a/crates/provider/src/shared/types.rs
+++ b/crates/provider/src/shared/types.rs
@@ -50,6 +50,8 @@ pub struct SpawnNodeOptions {
     /// Could be a local or remote asset
     pub db_snapshot: Option<AssetLocation>,
     pub port_mapping: Option<HashMap<Port, Port>>,
+    /// Optionally specify a log path for the node
+    pub node_log_path: Option<PathBuf>,
 }
 
 impl SpawnNodeOptions {
@@ -68,6 +70,7 @@ impl SpawnNodeOptions {
             created_paths: vec![],
             db_snapshot: None,
             port_mapping: None,
+            node_log_path: None,
         }
     }
 
@@ -132,6 +135,11 @@ impl SpawnNodeOptions {
 
     pub fn port_mapping(mut self, ports: HashMap<Port, Port>) -> Self {
         self.port_mapping = Some(ports);
+        self
+    }
+
+    pub fn node_log_path(mut self, path: Option<PathBuf>) -> Self {
+        self.node_log_path = path;
         self
     }
 }


### PR DESCRIPTION
This PR adds support for configuring a custom log_path for each node, including nodes created via group expansion.
If not specified, it defaults to the automatically generated default path.