### PR TITLE
Fix raw_path assignment timing to avoid reading non-existent raw spec file

### DIFF
--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -240,7 +240,12 @@ impl ChainSpec {
             //     check the [`DEFAULT_PRESETS_TO_CHECK`] in order to find one valid
             // - If we can't find any valid preset use the `default config` from the runtime
 
-            let preset = DEFAULT_PRESETS_TO_CHECK
+            let preset_to_check = if let Some(preset) = &runtime.preset {
+                [vec![preset.as_str()], DEFAULT_PRESETS_TO_CHECK.to_vec()].concat()
+            } else {
+                DEFAULT_PRESETS_TO_CHECK.to_vec()
+            };
+            let preset = preset_to_check
                 .iter()
                 .find(|preset| presets.iter().any(|item| item == *preset));
 
@@ -262,10 +267,10 @@ impl ChainSpec {
 
             let builder = if let Context::Para {
                 relay_chain: _,
-                para_id,
+                para_id: _,
             } = &self.context
             {
-                builder.with_id(&para_id.to_string())
+                builder.with_id(self.chain_spec_name())
             } else {
                 builder
             };
@@ -359,6 +364,7 @@ impl ChainSpec {
     where
         T: FileSystem,
     {
+        warn!("Building raw version from {:?}", self);
         // raw path already set, no more work to do here...
         let None = self.raw_path else {
             return Ok(());
@@ -366,7 +372,6 @@ impl ChainSpec {
 
         // expected raw path
         let raw_spec_path = PathBuf::from(format!("{}.json", self.chain_spec_name));
-        self.raw_path = Some(raw_spec_path.clone());
 
         if self.runtime.is_some() && self.asset_location.is_none() {
             // chain-spec created using the runtime
@@ -388,7 +393,7 @@ impl ChainSpec {
 
             let contents = if let Context::Para {
                 relay_chain: _,
-                para_id: _,
+                para_id,
             } = &self.context
             {
                 let mut contents_json: serde_json::Value = serde_json::from_str(&contents)
@@ -397,8 +402,13 @@ impl ChainSpec {
                             "getting chain-spec as json should work, err: {e}"
                         ))
                     })?;
+
                 if contents_json["relay_chain"].is_null() {
                     contents_json["relay_chain"] = json!(relay_chain_id);
+                }
+
+                if contents_json["para_id"].is_null() {
+                    contents_json["para_id"] = json!(para_id);
                 }
 
                 serde_json::to_string_pretty(&contents_json).map_err(|e| {
@@ -410,6 +420,7 @@ impl ChainSpec {
                 contents
             };
 
+            self.raw_path = Some(raw_spec_path.clone());
             self.write_spec(scoped_fs, contents).await?;
         } else {
             // fallback to use _cmd_ for raw creation
@@ -475,7 +486,7 @@ impl ChainSpec {
             };
             trace!("cmd: {:?} - args: {:?}", cmd, args);
 
-            let generate_command = GenerateFileCommand::new(cmd, raw_spec_path).args(args);
+            let generate_command = GenerateFileCommand::new(cmd, raw_spec_path.clone()).args(args);
 
             if let Some(CommandInContext::Local(_)) = self.command {
                 // local
@@ -494,6 +505,7 @@ impl ChainSpec {
                 trace!("calling generate_files with options: {:#?}", options);
                 ns.generate_files(options).await?;
             }
+            self.raw_path = Some(raw_spec_path);
         }
 
         Ok(())


### PR DESCRIPTION
Fixes an issue where raw_path was set before the raw spec file existed, causing failures when using .with_chain_spec_runtime in network build.