### PR TITLE
fix: relay chain chain_spec_command_output_path

### DIFF
--- a/crates/orchestrator/src/network_spec/relaychain.rs
+++ b/crates/orchestrator/src/network_spec/relaychain.rs
@@ -97,7 +97,7 @@ impl RelaychainSpec {
             .command(
                 tmpl.as_str(),
                 config.chain_spec_command_is_local(),
-                config.chain_spec_command(),
+                config.chain_spec_command_output_path(),
             )
             .image(main_image.clone());
 


### PR DESCRIPTION
This PR fixes a severe issue by which the relay chain takes the wrong output path.