### PR TITLE
feat: allow specifying the command's output path programmatically

### DIFF
--- a/crates/configuration/src/parachain.rs
+++ b/crates/configuration/src/parachain.rs
@@ -829,6 +829,18 @@ impl<C: Context> ParachainConfigBuilder<WithId, C> {
         )
     }
 
+    /// Set the output path for the chain-spec command.
+    pub fn with_chain_spec_command_output_path(self, output_path: &str) -> Self {
+        Self::transition(
+            ParachainConfig {
+                chain_spec_command_output_path: Some(output_path.to_string()),
+                ..self.config
+            },
+            self.validation_context,
+            self.errors,
+        )
+    }
+
     /// Set whether the parachain is based on cumulus (true in a majority of case, except adder or undying collators).
     pub fn cumulus_based(self, choice: bool) -> Self {
         Self::transition(

--- a/crates/configuration/src/relaychain.rs
+++ b/crates/configuration/src/relaychain.rs
@@ -446,6 +446,18 @@ impl RelaychainConfigBuilder<WithChain> {
         )
     }
 
+    /// Set the output path for the chain-spec command.
+    pub fn with_chain_spec_command_output_path(self, output_path: &str) -> Self {
+        Self::transition(
+            RelaychainConfig {
+                chain_spec_command_output_path: Some(output_path.to_string()),
+                ..self.config
+            },
+            self.validation_context,
+            self.errors,
+        )
+    }
+
     /// Set the number of `random nominators` to create for chains using staking, this is used in tandem with `max_nominations` to simulate the amount of nominators and nominations.
     pub fn with_random_nominators_count(self, random_nominators_count: u32) -> Self {
         Self::transition(


### PR DESCRIPTION
This PR allows specifying the `chain_spec_command_output_path` in the SDK.