### PR TITLE
TUI improve error message format

### DIFF
--- a/crates/orchestrator/src/errors.rs
+++ b/crates/orchestrator/src/errors.rs
@@ -20,11 +20,11 @@ pub enum OrchestratorError {
     GlobalTimeOut(u32),
     #[error("Generator error: {0}")]
     GeneratorError(#[from] generators::errors::GeneratorError),
-    #[error("Provider error")]
+    #[error("Provider error: {0}")]
     ProviderError(#[from] ProviderError),
-    #[error("FileSystem error")]
+    #[error("FileSystem error: {0}")]
     FileSystemError(#[from] FileSystemError),
-    #[error("Serialization error")]
+    #[error("Serialization error: {0}")]
     SerializationError(#[from] serde_json::Error),
     #[error(transparent)]
     SpawnerError(#[from] anyhow::Error),

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -560,7 +560,10 @@ async fn recreate_network_nodes_from_json(
             .get("provider_tag")
             .and_then(|v| v.as_str())
             .ok_or_else(|| {
-                OrchestratorError::InvalidConfig("Missing `provider_tag` in inner node JSON".into())
+                OrchestratorError::InvalidConfig(format!(
+                    "Node '{}' is missing `provider_tag` in inner node JSON",
+                    raw.name
+                ))
             })?;
 
         if provider_tag != provider_name {

--- a/crates/orchestrator/src/network/node.rs
+++ b/crates/orchestrator/src/network/node.rs
@@ -56,6 +56,7 @@ pub(crate) struct RawNetworkNode {
     pub(crate) prometheus_uri: String,
     pub(crate) multiaddr: String,
     pub(crate) spec: NodeSpec,
+    #[serde(default)]
     pub(crate) inner: serde_json::Value,
 }
 

--- a/crates/orchestrator/src/network/parachain.rs
+++ b/crates/orchestrator/src/network/parachain.rs
@@ -32,7 +32,9 @@ pub struct Parachain {
     pub(crate) chain_spec_path: Option<PathBuf>,
     #[serde(default, deserialize_with = "default_as_empty_vec")]
     pub(crate) collators: Vec<NetworkNode>,
+    #[serde(default)]
     pub(crate) files_to_inject: Vec<TransferedFile>,
+    #[serde(default)]
     pub(crate) bootnodes_addresses: Vec<multiaddr::Multiaddr>,
 }
 

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -109,7 +109,7 @@ pub enum ProviderError {
     #[error("Failed to delete namespace '{0}': {1}")]
     DeleteNamespaceFailed(String, anyhow::Error),
 
-    #[error("Serialization error")]
+    #[error("Serialization error: {0}")]
     SerializationError(#[from] serde_json::Error),
 
     #[error("Failed to acquire lock: {0}")]

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -101,7 +101,7 @@ async fn run_app(
 ) -> Result<()> {
     // Attempt to attach to the network.
     if let Err(e) = app.attach_to_network().await {
-        app.set_status(format!("Failed to attach: {}. Press 'q' to quit.", e));
+        app.set_status(format!("Failed to attach: {:#}. Press 'q' to quit.", e));
     }
 
     loop {


### PR DESCRIPTION
There were multiple problems causing deserialization failures when attaching to a `zombie.json` created by an older version of zombienet-sdk.

- Did not serialize the inner field (provider-specific node data like PID)   
- Didn't have several fields (`keystore_key_types`, `chain_spec_key_types`, `bootnodes_addresses`) 

