### PR TITLE
feat: add logic to allow to override rc session 0 and make paras prod…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10928,6 +10928,7 @@ dependencies = [
  "regex",
  "reqwest",
  "serde_json",
+ "sp-core",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/crates/configuration/src/relaychain.rs
+++ b/crates/configuration/src/relaychain.rs
@@ -58,6 +58,8 @@ pub struct RelaychainConfig {
     /// Optional post-process script to run after chain-spec generation.
     #[serde(skip_serializing_if = "Option::is_none")]
     post_process_script: Option<String>,
+    #[serde(skip_serializing_if = "is_false", default)]
+    override_session_0: bool,
 }
 
 impl RelaychainConfig {
@@ -109,6 +111,10 @@ impl RelaychainConfig {
     /// Does the chain_spec_command needs to be run locally
     pub fn chain_spec_command_is_local(&self) -> bool {
         self.chain_spec_command_is_local
+    }
+
+    pub fn override_session_0(&self) -> bool {
+        self.override_session_0
     }
 
     /// The file where the `chain_spec_command` will write the chain-spec into.
@@ -208,6 +214,7 @@ impl Default for RelaychainConfigBuilder<Initial> {
                 node_groups: vec![],
                 raw_spec_override: None,
                 post_process_script: None,
+                override_session_0: false,
             },
             validation_context: Default::default(),
             errors: vec![],
@@ -454,6 +461,19 @@ impl RelaychainConfigBuilder<WithChain> {
         Self::transition(
             RelaychainConfig {
                 chain_spec_command_is_local: choice,
+                ..self.config
+            },
+            self.validation_context,
+            self.errors,
+        )
+    }
+
+    /// Set to true to override session 0 and allow paras to produce
+    /// blocks from genesis.
+    pub fn with_override_session_0(self, choice: bool) -> Self {
+        Self::transition(
+            RelaychainConfig {
+                override_session_0: choice,
                 ..self.config
             },
             self.validation_context,

--- a/crates/orchestrator/src/generators.rs
+++ b/crates/orchestrator/src/generators.rs
@@ -12,6 +12,7 @@ mod identity;
 mod keystore;
 mod keystore_key_types;
 mod port;
+mod session_0_overrides;
 
 pub use bootnode_addr::generate as generate_node_bootnode_addr;
 pub use command::{
@@ -22,3 +23,4 @@ pub use identity::generate as generate_node_identity;
 pub use key::generate as generate_node_keys;
 pub use keystore::generate as generate_node_keystore;
 pub use port::generate as generate_node_port;
+pub use session_0_overrides::generate_session_0_overrides;

--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -655,11 +655,10 @@ impl ChainSpec {
         Ok(())
     }
 
-    pub async fn override_raw_spec<'a, T>(
-        &mut self,
+    pub async fn read_raw_spec<'a, T>(
+        &self,
         scoped_fs: &ScopedFilesystem<'a, T>,
-        raw_spec_overrides: &JsonOverrides,
-    ) -> Result<(), GeneratorError>
+    ) -> Result<serde_json::Value, GeneratorError>
     where
         T: FileSystem,
     {
@@ -672,18 +671,31 @@ impl ChainSpec {
 
         let (content, _) = self.read_spec(scoped_fs).await?;
 
+        // read spec to json value
+        let chain_spec_json: serde_json::Value = serde_json::from_str(&content).map_err(|_| {
+            GeneratorError::ChainSpecGeneration("Can not parse chain-spec as json".into())
+        })?;
+
+        Ok(chain_spec_json)
+    }
+
+    pub async fn override_raw_spec<'a, T>(
+        &mut self,
+        scoped_fs: &ScopedFilesystem<'a, T>,
+        raw_spec_overrides: &JsonOverrides,
+    ) -> Result<(), GeneratorError>
+    where
+        T: FileSystem,
+    {
+        // read spec to json value
+        let mut chain_spec_json: serde_json::Value = self.read_raw_spec(scoped_fs).await?;
+
         // read overrides to json value
         let override_content: serde_json::Value = raw_spec_overrides.get().await.map_err(|_| {
             GeneratorError::OverridingRawSpec(format!(
                 "Can not parse raw_spec_override contents as json: {raw_spec_overrides}"
             ))
         })?;
-
-        // read spec to json value
-        let mut chain_spec_json: serde_json::Value =
-            serde_json::from_str(&content).map_err(|_| {
-                GeneratorError::ChainSpecGeneration("Can not parse chain-spec as json".into())
-            })?;
 
         // merge overrides with existing spec
         merge(&mut chain_spec_json, &override_content);

--- a/crates/orchestrator/src/generators/core_assignment.rs
+++ b/crates/orchestrator/src/generators/core_assignment.rs
@@ -1,6 +1,6 @@
 use array_bytes::bytes2hex;
 use codec::{CompactAs, Decode, Encode, MaxEncodedLen};
-use sp_core::storage::StorageKey;
+use support::substorage::storage_value_key;
 use tracing::trace;
 
 /// Parachain id.
@@ -60,20 +60,4 @@ pub fn generate(core_index: u32, para_id: u32) -> String {
 
     trace!("core_descriptor part: {core_descriptor}");
     core_descriptor
-}
-
-// Helpers from subhasher / substorage
-
-/// Calculate the storage key of a pallet `StorageValue` item.
-pub fn storage_value_key<A, B>(pallet: A, item: B) -> StorageKey
-where
-    A: AsRef<[u8]>,
-    B: AsRef<[u8]>,
-{
-    let mut k = Vec::new();
-
-    k.extend_from_slice(&sp_core::twox_128(pallet.as_ref()));
-    k.extend_from_slice(&sp_core::twox_128(item.as_ref()));
-
-    StorageKey(k)
 }

--- a/crates/orchestrator/src/generators/errors.rs
+++ b/crates/orchestrator/src/generators/errors.rs
@@ -21,4 +21,8 @@ pub enum GeneratorError {
     OverridingWasm(String),
     #[error("Error overriding raw chain-spec, err {0}")]
     OverridingRawSpec(String),
+    #[error("Encode/decode error: {0}")]
+    EncodeDecodeError(String),
+    #[error("Invariant error: {0}")]
+    InvariantError(String),
 }

--- a/crates/orchestrator/src/generators/session_0_overrides.rs
+++ b/crates/orchestrator/src/generators/session_0_overrides.rs
@@ -1,0 +1,215 @@
+use array_bytes::bytes2hex;
+use codec::{Decode, Encode};
+use serde_json::json;
+use sp_core::crypto::AccountId32;
+use support::substorage::storage_value_key;
+
+use crate::generators::errors::GeneratorError;
+
+// Extracted and simplified from polkadot-sdk
+
+/// Index of the validator is used as a lightweight replacement of the `ValidatorId` when
+/// appropriate.
+#[derive(PartialEq, Clone, Encode, Decode, Debug)]
+pub struct ValidatorIndex(pub u32);
+
+/// Simple index type with which we can count sessions.
+pub type SessionIndex = u32;
+
+/// The unique (during session) index of a validator group.
+#[derive(Encode, Decode, Default, Clone, Debug, PartialEq)]
+pub struct GroupIndex(pub u32);
+
+#[derive(Clone, Encode, Decode, Debug, PartialEq)]
+pub struct SessionInfo {
+    /// **** New in v2 ******
+    /// All the validators actively participating in parachain consensus.
+    /// Indices are into the broader validator set.
+    pub active_validator_indices: Vec<ValidatorIndex>,
+    /// A secure random seed for the session, gathered from BABE.
+    pub random_seed: [u8; 32],
+    /// The amount of sessions to keep for disputes.
+    pub dispute_period: SessionIndex,
+
+    /// **** Old fields *****
+    /// Validators in canonical ordering.
+    ///
+    /// NOTE: There might be more authorities in the current session, than `validators`
+    /// participating in parachain consensus. See
+    /// [`max_validators`](https://github.com/paritytech/polkadot/blob/a52dca2be7840b23c19c153cf7e110b1e3e475f8/runtime/parachains/src/configuration.rs#L148).
+    ///
+    /// `SessionInfo::validators` will be limited to `max_validators` when set.
+    pub validators: Vec<AccountId32>,
+    /// Validators' authority discovery keys for the session in canonical ordering.
+    ///
+    /// NOTE: The first `validators.len()` entries will match the corresponding validators in
+    /// `validators`, afterwards any remaining authorities can be found. This is any authorities
+    /// not participating in parachain consensus - see
+    /// [`max_validators`](https://github.com/paritytech/polkadot/blob/a52dca2be7840b23c19c153cf7e110b1e3e475f8/runtime/parachains/src/configuration.rs#L148)
+    pub discovery_keys: Vec<AccountId32>,
+    /// The assignment keys for validators.
+    ///
+    /// NOTE: There might be more authorities in the current session, than validators participating
+    /// in parachain consensus. See
+    /// [`max_validators`](https://github.com/paritytech/polkadot/blob/a52dca2be7840b23c19c153cf7e110b1e3e475f8/runtime/parachains/src/configuration.rs#L148).
+    ///
+    pub assignment_keys: Vec<AccountId32>,
+    /// Validators in shuffled ordering - these are the validator groups as produced
+    /// by the `Scheduler` module for the session and are typically referred to by
+    /// `GroupIndex`.
+    pub validator_groups: Vec<Vec<ValidatorIndex>>,
+    /// The number of availability cores used by the protocol during this session.
+    pub n_cores: u32,
+    /// The zeroth delay tranche width.
+    pub zeroth_delay_tranche_width: u32,
+    /// The number of samples we do of `relay_vrf_modulo`.
+    pub relay_vrf_modulo_samples: u32,
+    /// The number of delay tranches in total.
+    pub n_delay_tranches: u32,
+    /// How many slots (BABE / SASSAFRAS) must pass before an assignment is considered a
+    /// no-show.
+    pub no_show_slots: u32,
+    /// The number of validators needed to approve a block.
+    pub needed_approvals: u32,
+}
+
+pub fn generate_session_0_overrides(
+    raw_spec: &serde_json::Value,
+    num_genesis_cores: u32,
+) -> Result<serde_json::Value, GeneratorError> {
+    let mut overrides = json!({});
+    // get current session 0
+    let sessions_prefix = storage_value_key(&b"ParaSessionInfo"[..], b"Sessions");
+    let session_0_key = format!(
+        "{}{}",
+        bytes2hex("0x", &sessions_prefix),
+        bytes2hex("", 0_u32.encode())
+    );
+
+    let current_value = &raw_spec["genesis"]["raw"]["top"][&session_0_key];
+    let Some(current_value_inner) = current_value.as_str() else {
+        return Err(GeneratorError::OverridingRawSpec(format!(
+            "Session_0 keys {} is missing (in genesis.raw.top)",
+            session_0_key
+        )));
+    };
+
+    let encoded = hex::decode(&current_value_inner[2..]).map_err(|e| {
+        GeneratorError::EncodeDecodeError(format!(
+            "Error decoding hex: {}, err: {e}",
+            current_value_inner
+        ))
+    })?;
+    let mut session: SessionInfo = SessionInfo::decode(&mut encoded.as_slice()).map_err(|e| {
+        GeneratorError::EncodeDecodeError(format!("Error decoding scale: {:?}, err: {e}", encoded))
+    })?;
+
+    // clone keys
+    session.assignment_keys = session.validators.clone();
+    session.discovery_keys = session.validators.clone();
+
+    // generate validator groups
+
+    // some checks first
+    if num_genesis_cores >= session.validators.len() as u32 {
+        return Err(GeneratorError::InvariantError(format!("Num cores in genesis {num_genesis_cores} should be less than the num of validators ({})", session.validators.len())));
+    }
+
+    let groups = genetate_groups(session.validators.len() as u32, num_genesis_cores);
+    session.validator_groups = groups.clone();
+    session.n_cores = num_genesis_cores;
+
+    // done with session
+    let session_0_value = bytes2hex("0x", session.encode());
+    overrides[session_0_key] = json!(session_0_value);
+
+    // paraScheduler.validatorGroups: Vec<Vec<u32>>
+    let para_scheduler_validator_groups_key = bytes2hex(
+        "0x",
+        storage_value_key(&b"ParaScheduler"[..], b"ValidatorGroups"),
+    );
+
+    overrides[para_scheduler_validator_groups_key] = json!(bytes2hex("0x", groups.encode()));
+
+    Ok(overrides)
+}
+
+fn genetate_groups(num_validators: u32, num_cores: u32) -> Vec<Vec<ValidatorIndex>> {
+    let iter = std::iter::repeat(vec![]).take(num_cores as usize);
+    let mut groups: Vec<Vec<ValidatorIndex>> = Vec::from_iter(iter);
+    for i in 0..num_validators {
+        let index = i % num_cores;
+        let group = groups.get_mut(index as usize).expect(&format!(
+            "Group index {index} should be part of groups. qed"
+        ));
+        group.push(ValidatorIndex(i));
+    }
+
+    groups
+}
+
+#[cfg(test)]
+mod test {
+    use tracing::debug;
+
+    use super::*;
+
+    #[test]
+    fn decode_encode_should_work() {
+        use support::substorage::storage_value_key;
+
+        let k = storage_value_key(&b"ParaSessionInfo"[..], b"Sessions");
+        debug!("k: {}{}", bytes2hex("", &k), bytes2hex("", 0_u32.encode()));
+
+        let encoded = hex::decode( "1003000000010000000000000002000000abc3f086f5ac20eaab792c75933b2e196307835a61a955be82aa63bc0ff9617a06000000108eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d90b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22306721211d5404bd9da88e0204360a1a9ab8b87c66c1bc2fcdd37f3c2222cc20000000000000000000000000000000010000000100000000000000").unwrap();
+        let mut session: SessionInfo = SessionInfo::decode(&mut encoded.as_slice()).unwrap();
+
+        debug!("{session:?}");
+
+        session.assignment_keys = session.validators.clone();
+        session.discovery_keys = session.validators.clone();
+
+        let encoded = session.encode();
+        debug!("{}", bytes2hex("", &encoded));
+
+        let session_modified = SessionInfo::decode(&mut &encoded[..]).unwrap();
+
+        debug!("{session_modified:?}");
+    }
+
+    #[test]
+    fn val_groups() {
+        let num_cores = 3_u32;
+        let validators = ["abc", "cds", "qwe", "eds"];
+        let groups = genetate_groups(validators.len() as u32, num_cores);
+
+        debug!("{:?}", groups);
+        assert_eq!(groups.len(), num_cores as usize);
+    }
+
+    #[test]
+    fn generate_should_work() {
+        let sessions_prefix = storage_value_key(&b"ParaSessionInfo"[..], b"Sessions");
+        let session_0_key = format!(
+            "{}{}",
+            bytes2hex("0x", &sessions_prefix),
+            bytes2hex("", 0_u32.encode())
+        );
+
+        let session_value = "0x1003000000010000000000000002000000abc3f086f5ac20eaab792c75933b2e196307835a61a955be82aa63bc0ff9617a06000000108eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d90b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22306721211d5404bd9da88e0204360a1a9ab8b87c66c1bc2fcdd37f3c2222cc20000000000000000000000000000000010000000100000000000000";
+        let mock_spec = json!({
+            "genesis": {
+                "raw": {
+                    "top": {
+                        session_0_key: session_value
+                    }
+                }
+            }
+        });
+
+        debug!("mock {:?}", mock_spec);
+
+        let overrides = generate_session_0_overrides(&mock_spec, 3).unwrap();
+        debug!("{:?}", overrides);
+    }
+}

--- a/crates/orchestrator/src/generators/session_0_overrides.rs
+++ b/crates/orchestrator/src/generators/session_0_overrides.rs
@@ -52,7 +52,6 @@ pub struct SessionInfo {
     /// NOTE: There might be more authorities in the current session, than validators participating
     /// in parachain consensus. See
     /// [`max_validators`](https://github.com/paritytech/polkadot/blob/a52dca2be7840b23c19c153cf7e110b1e3e475f8/runtime/parachains/src/configuration.rs#L148).
-    ///
     pub assignment_keys: Vec<AccountId32>,
     /// Validators in shuffled ordering - these are the validator groups as produced
     /// by the `Scheduler` module for the session and are typically referred to by

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -21,6 +21,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
+use anyhow::anyhow;
 use configuration::{types::JsonOverrides, NetworkConfig, RegistrationStrategy};
 use errors::OrchestratorError;
 use generators::{core_assignment, errors::GeneratorError};
@@ -308,7 +309,10 @@ where
         }
 
         // assign extra cores if needed
-        if num_cores > para_to_register_in_genesis.len() as u32 {
+        debug!("Raw overrides info: num_cores: {}, para_to_register_in_genesis_len: {:?}, override_session_0: {}", num_cores, para_to_register_in_genesis.len(), network_spec.relaychain().override_session_0);
+        if num_cores > para_to_register_in_genesis.len() as u32
+            || network_spec.relaychain().override_session_0
+        {
             let mut core_index = 0u32;
             // we should check with version the runtime is using
             // could be ParaScheduler or CoretimeAssignmentProvider
@@ -319,24 +323,42 @@ where
                 .find_raw_key(&scoped_fs, &scheduler_key)
                 .await?;
             let mut para_scheduler_value_parts: Vec<String> = vec![];
-            let mut core_json_overrides = json!({});
+            let mut raw_json_overrides = json!({});
             // loop over para and assign cores from 0..
             for para in &network_spec.parachains {
-                if let Some(mut cores) = para.num_cores {
+                // cores we need to assign
+                let mut cores_for_para = 0_u32;
+                if let Some(cores) = para.num_cores {
                     if &RegistrationStrategy::InGenesis == para.registration_strategy() && is_old {
-                        cores -= 1;
+                        cores_for_para = cores - 1;
                     }
-                    for _core in 0..cores {
-                        if is_old {
-                            let (core_assign_key, core_assign_value) =
-                                core_assignment::generate_old(core_index, para.id);
-                            core_json_overrides[core_assign_key] = json!(core_assign_value);
-                        } else {
-                            let part = core_assignment::generate(core_index, para.id);
-                            para_scheduler_value_parts.push(part);
-                        }
-                        core_index += 1;
+                } else {
+                    // no num_cores set but we need to check if `override_session_0` is true
+                    // to assign the first core.
+                    if &RegistrationStrategy::InGenesis == para.registration_strategy() && is_old {
+                        cores_for_para += 1;
                     }
+                }
+
+                trace!(
+                    "Assigning cores {cores_for_para} in raw spec for para {}. Using pallet {}",
+                    para.id,
+                    if is_old {
+                        "CoretimeAssignmentProvider"
+                    } else {
+                        "ParaScheduler"
+                    }
+                );
+                for _core in 0..cores_for_para {
+                    if is_old {
+                        let (core_assign_key, core_assign_value) =
+                            core_assignment::generate_old(core_index, para.id);
+                        raw_json_overrides[core_assign_key] = json!(core_assign_value);
+                    } else {
+                        let part = core_assignment::generate(core_index, para.id);
+                        para_scheduler_value_parts.push(part);
+                    }
+                    core_index += 1;
                 }
             }
 
@@ -345,7 +367,24 @@ where
                 let count_prefix = format!("{:02x}", para_scheduler_value_parts.len() * 4);
                 let core_assign_value =
                     format!("{count_prefix}{}", para_scheduler_value_parts.join(""));
-                core_json_overrides[scheduler_key] = json!(core_assign_value);
+                raw_json_overrides[scheduler_key] = json!(core_assign_value);
+            }
+
+            // extra check to ensure we need to override session 0
+            if network_spec.relaychain().override_session_0 {
+                trace!("Overriding pallet ParaSessionInfo.session (0) to allow paras to produce blocks at first session.");
+                let raw_spec = network_spec
+                    .relaychain
+                    .chain_spec
+                    .read_raw_spec(&scoped_fs)
+                    .await?;
+                let overrides = generators::generate_session_0_overrides(&raw_spec, num_cores)?;
+
+                for (k, v) in overrides.as_object().ok_or(anyhow!(
+                    "'generate_session_0_overrides' should be a valid json Object."
+                ))? {
+                    raw_json_overrides[k] = v.clone();
+                }
             }
 
             network_spec
@@ -356,7 +395,7 @@ where
                     &JsonOverrides::Json(json!({
                         "genesis": {
                             "raw": {
-                                "top": core_json_overrides
+                                "top": raw_json_overrides
                             }
                         }
                     })),

--- a/crates/orchestrator/src/network_spec/relaychain.rs
+++ b/crates/orchestrator/src/network_spec/relaychain.rs
@@ -63,6 +63,10 @@ pub struct RelaychainSpec {
 
     /// Optional post-process script configured for this relaychain
     pub(crate) post_process_script: Option<String>,
+
+    /// Set to true to override session 0 and allow paras to produce
+    /// blocks from genesis.
+    pub(crate) override_session_0: bool,
 }
 
 impl RelaychainSpec {
@@ -172,6 +176,7 @@ impl RelaychainSpec {
             nodes,
             raw_spec_override: config.raw_spec_override().cloned(),
             post_process_script: config.post_process_script().map(str::to_string),
+            override_session_0: config.override_session_0(),
         })
     }
 

--- a/crates/support/Cargo.toml
+++ b/crates/support/Cargo.toml
@@ -26,3 +26,4 @@ regex = { workspace = true }
 tracing = { workspace = true }
 lazy_static = { workspace = true }
 serde_json = { workspace = true }
+sp-core = { workspace = true }

--- a/crates/support/src/lib.rs
+++ b/crates/support/src/lib.rs
@@ -2,3 +2,4 @@ pub mod constants;
 pub mod fs;
 pub mod net;
 pub mod replacer;
+pub mod substorage;

--- a/crates/support/src/substorage.rs
+++ b/crates/support/src/substorage.rs
@@ -1,0 +1,17 @@
+use sp_core::storage::StorageKey;
+
+// Helpers from subhasher / substorage
+
+/// Calculate the storage key of a pallet `StorageValue` item.
+pub fn storage_value_key<A, B>(pallet: A, item: B) -> StorageKey
+where
+    A: AsRef<[u8]>,
+    B: AsRef<[u8]>,
+{
+    let mut k = Vec::new();
+
+    k.extend_from_slice(&sp_core::twox_128(pallet.as_ref()));
+    k.extend_from_slice(&sp_core::twox_128(item.as_ref()));
+
+    StorageKey(k)
+}


### PR DESCRIPTION
…uce blocks

- Add Relaychain config `override_session_0` (default __false__), when this is set to _true_ zombienet will override these keys in raw mode, allowing paras to produce blocks in the first session:
  -  ParaSessionInfo.sessions(0)
  - ParaScheduler.ValidatorGroups
  - CoretimeAssignmentProvider.CoreDescriptors or ParaScheduler.CoreDescriptors (depends of runtime version).

cc: @0xOmarA 