### PR TITLE
bump version for release `v0.4.10`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10750,7 +10750,7 @@ dependencies = [
 
 [[package]]
 name = "zombie-cli"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -10762,7 +10762,7 @@ dependencies = [
 
 [[package]]
 name = "zombie-tui"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -10786,7 +10786,7 @@ dependencies = [
 
 [[package]]
 name = "zombienet-configuration"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -10805,7 +10805,7 @@ dependencies = [
 
 [[package]]
 name = "zombienet-file-server"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "axum",
  "axum-extra",
@@ -10820,7 +10820,7 @@ dependencies = [
 
 [[package]]
 name = "zombienet-orchestrator"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "array-bytes",
@@ -10858,7 +10858,7 @@ dependencies = [
 
 [[package]]
 name = "zombienet-prom-metrics-parser"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "pest",
  "pest_derive",
@@ -10867,7 +10867,7 @@ dependencies = [
 
 [[package]]
 name = "zombienet-provider"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10897,7 +10897,7 @@ dependencies = [
 
 [[package]]
 name = "zombienet-sdk"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "async-trait",
  "futures",
@@ -10917,7 +10917,7 @@ dependencies = [
 
 [[package]]
 name = "zombienet-support"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ default-members = [
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.4.9"
+version = "0.4.10"
 rust-version = "1.79.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/zombienet-sdk"
@@ -86,9 +86,9 @@ walkdir = "2.5"
 codec = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = ["derive"] }
 
 # Zombienet workspace crates:
-support = { package = "zombienet-support", version = "0.4.9", path = "crates/support" }
-configuration = { package = "zombienet-configuration", version = "0.4.9", path = "crates/configuration" }
-orchestrator = { package = "zombienet-orchestrator", version = "0.4.9", path = "crates/orchestrator" }
-provider = { package = "zombienet-provider", version = "0.4.9", path = "crates/provider" }
-prom-metrics-parser = { package = "zombienet-prom-metrics-parser", version = "0.4.9", path = "crates/prom-metrics-parser" }
-zombienet-sdk = { version = "0.4.9", path = "crates/sdk" }
+support = { package = "zombienet-support", version = "0.4.10", path = "crates/support" }
+configuration = { package = "zombienet-configuration", version = "0.4.10", path = "crates/configuration" }
+orchestrator = { package = "zombienet-orchestrator", version = "0.4.10", path = "crates/orchestrator" }
+provider = { package = "zombienet-provider", version = "0.4.10", path = "crates/provider" }
+prom-metrics-parser = { package = "zombienet-prom-metrics-parser", version = "0.4.10", path = "crates/prom-metrics-parser" }
+zombienet-sdk = { version = "0.4.10", path = "crates/sdk" }


### PR DESCRIPTION
Added:
 - override_session_0 (RC)
 - restart_with (NetworkNodes)
 - Assign cores at genesis with `num_cores` (in paras).

@0xOmarA / @tdimitrov 