### PR TITLE
snapshot cache added: race avoided

### DIFF
--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           export ZOMBIE_K8S_CI_NAMESPACE=$(cat /data/namespace)
           mkdir -p /tmp/zombie-1/logs
-          
+
           # Install kubectl if not available
           if ! command -v kubectl &> /dev/null; then
             echo "Installing kubectl..."
@@ -89,7 +89,7 @@ jobs:
             chmod +x kubectl
             mv kubectl /usr/local/bin/
           fi
-          
+
           echo "Listing pods in namespace $ZOMBIE_K8S_CI_NAMESPACE..."
           kubectl get pods -n "$ZOMBIE_K8S_CI_NAMESPACE" -o wide || true
           for pod in $(kubectl get pods -n "$ZOMBIE_K8S_CI_NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true); do
@@ -109,7 +109,7 @@ jobs:
             /tmp/zombie-1/logs/*
 
   docker-integration-test-smoke:
-    runs-on: parity-default
+    runs-on: parity-zombienet
     needs: build-tests
     timeout-minutes: 60
     steps:

--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -173,7 +173,7 @@ jobs:
         run: |
           for bin in polkadot polkadot-execute-worker polkadot-prepare-worker polkadot-omni-node polkadot-parachain; do
             echo "downloading $bin";
-            curl -L -o /tmp/$bin https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-stable2503-1/$bin;
+            curl --retry 3 -L -o /tmp/$bin https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-stable2603-2/$bin;
             chmod 755 /tmp/$bin;
           done
           ls -ltr /tmp

--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -109,7 +109,7 @@ jobs:
             /tmp/zombie-1/logs/*
 
   docker-integration-test-smoke:
-    runs-on: parity-zombienet
+    runs-on: parity-zombienet-native-default
     needs: build-tests
     timeout-minutes: 60
     steps:
@@ -131,6 +131,7 @@ jobs:
         timeout-minutes: 45
         run: |
           export ZOMBIE_PROVIDER="docker"
+          export RUST_LOG="zombienet_orchestrator=debug,zombienet_provider=debug,zombienet_provider::docker=trace"
           cd /tmp
           ls -la
           tar xvfz artifacts.tar.gz

--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -131,7 +131,6 @@ jobs:
         timeout-minutes: 45
         run: |
           export ZOMBIE_PROVIDER="docker"
-          export RUST_LOG="zombienet_orchestrator=debug,zombienet_provider=debug,zombienet_provider::docker=trace"
           cd /tmp
           ls -la
           tar xvfz artifacts.tar.gz
@@ -209,7 +208,7 @@ jobs:
             /tmp/zombie-1/logs/*
 
   docker-integration-test-chain-spec-runtime-omni-node:
-    runs-on: parity-default
+    runs-on: parity-zombienet-native-default
     needs: build-tests
     timeout-minutes: 60
     steps:
@@ -256,7 +255,7 @@ jobs:
             /tmp/zombie-1/logs/*
 
   docker-integration-test-chain-spec-runtime-polkadot:
-    runs-on: parity-default
+    runs-on: parity-zombienet-native-default
     needs: build-tests
     timeout-minutes: 60
     steps:

--- a/crates/configuration/src/shared/types.rs
+++ b/crates/configuration/src/shared/types.rs
@@ -288,7 +288,7 @@ impl CommandWithCustomArgs {
 /// assert!(matches!(path_location, AssetLocation::FilePath(value) if value.to_str().unwrap() == "/tmp/path/to/my/file"));
 /// assert!(matches!(path_location2, AssetLocation::FilePath(value) if value.to_str().unwrap() == "/tmp/path/to/my/file"));
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AssetLocation {
     Url(Url),
     FilePath(PathBuf),

--- a/crates/orchestrator/src/generators.rs
+++ b/crates/orchestrator/src/generators.rs
@@ -1,4 +1,5 @@
 pub mod chain_spec;
+pub mod db_snapshot;
 pub mod errors;
 pub mod key;
 pub mod para_artifact;
@@ -19,6 +20,7 @@ pub use command::{
     generate_for_cumulus_node as generate_node_command_cumulus,
     generate_for_node as generate_node_command, GenCmdOptions,
 };
+pub use db_snapshot::{cleanup_db_snapshot_cache, resolve_db_snapshots, ResolvedDbSnapshots};
 pub use identity::generate as generate_node_identity;
 pub use key::generate as generate_node_keys;
 pub use keystore::generate as generate_node_keystore;

--- a/crates/orchestrator/src/generators/db_snapshot.rs
+++ b/crates/orchestrator/src/generators/db_snapshot.rs
@@ -1,0 +1,101 @@
+//! Resolve `db_snapshot` `AssetLocation`s into local cache paths, once per
+//! unique location, **before** the parallel spawn fanout.
+//!
+//! Cache layout is: `{ns_base_dir}/{sha256(loc_str)}.tgz`. The
+//! provider's `initialize_db_snapshot` now takes a `&Path` to this
+//! already-resolved file and only has to extract it.
+
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+use configuration::types::AssetLocation;
+use provider::{DynNamespace, ProviderError};
+use sha2::Digest;
+use support::fs::FileSystem;
+use tracing::trace;
+
+use crate::network_spec::node::NodeSpec;
+
+/// Lookup map produced by [`resolve_db_snapshots`].
+pub type ResolvedDbSnapshots = HashMap<AssetLocation, PathBuf>;
+
+/// Walk every node's `db_snapshot`, deduplicate by `AssetLocation`, and
+/// fetch each unique location once into the namespace cache. Returns a
+/// map from the original `AssetLocation` to the local cache `PathBuf`.
+pub async fn resolve_db_snapshots<'a, FS, I>(
+    nodes: I,
+    ns: &DynNamespace,
+    filesystem: &FS,
+) -> Result<ResolvedDbSnapshots, ProviderError>
+where
+    FS: FileSystem,
+    I: IntoIterator<Item = &'a NodeSpec>,
+{
+    let ns_base_dir = ns.base_dir().to_string_lossy().to_string();
+    let mut resolved: ResolvedDbSnapshots = HashMap::new();
+
+    for loc in nodes.into_iter().filter_map(|n| n.db_snapshot.as_ref()) {
+        if resolved.contains_key(loc) {
+            continue;
+        }
+        let hashed = hex::encode(sha2::Sha256::digest(loc.to_string()));
+        let cache_path = PathBuf::from(format!("{ns_base_dir}/{hashed}.tgz"));
+        if !filesystem.exists(&cache_path).await {
+            fetch_into_cache(loc, &cache_path, filesystem).await?;
+        } else {
+            trace!("db_snapshot cache hit: {}", cache_path.display());
+        }
+        resolved.insert(loc.clone(), cache_path);
+    }
+
+    Ok(resolved)
+}
+
+/// Remove cache tarballs after all consumers have finished extracting them,
+/// gated by the `ZOMBIE_RM_TGZ_AFTER_EXTRACT` env var. Best-effort: errors
+/// are logged and swallowed (cleanup must never fail spawn).
+///
+/// Must be called only after every node that consumes the cache has
+/// completed its `initialize_db_snapshot` — otherwise concurrent readers
+/// will hit `ENOENT`.
+pub async fn cleanup_db_snapshot_cache(resolved: &ResolvedDbSnapshots) {
+    if std::env::var("ZOMBIE_RM_TGZ_AFTER_EXTRACT").is_err() {
+        return;
+    }
+    for cache_path in resolved.values() {
+        match tokio::fs::remove_file(cache_path).await {
+            Ok(()) => trace!("removed cache {}", cache_path.display()),
+            Err(err) => trace!("failed to remove cache {}: {err}", cache_path.display()),
+        }
+    }
+}
+
+async fn fetch_into_cache<FS: FileSystem>(
+    location: &AssetLocation,
+    cache_path: &Path,
+    filesystem: &FS,
+) -> Result<(), ProviderError> {
+    trace!(
+        "resolving db_snapshot {} -> {}",
+        location,
+        cache_path.display()
+    );
+    match location {
+        AssetLocation::Url(url) => {
+            let res = reqwest::get(url.as_ref())
+                .await
+                .map_err(|err| ProviderError::DownloadFile(url.to_string(), err.into()))?;
+            let bytes = res
+                .bytes()
+                .await
+                .map_err(|err| ProviderError::DownloadFile(url.to_string(), err.into()))?;
+            filesystem.write(cache_path, &bytes[..]).await?;
+        },
+        AssetLocation::FilePath(filepath) => {
+            filesystem.copy(filepath, cache_path).await?;
+        },
+    }
+    Ok(())
+}

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -188,6 +188,21 @@ where
             .populate_nodes_available_args(ns.clone())
             .await?;
 
+        // Resolve every node's `db_snapshot` AssetLocation into a local
+        // cache file once, serially, before any parallel spawn.
+        let all_nodes: Vec<&NodeSpec> = network_spec
+            .relaychain()
+            .nodes
+            .iter()
+            .chain(
+                network_spec
+                    .parachains_iter()
+                    .flat_map(|p| p.collators.iter()),
+            )
+            .collect();
+        let resolved_db_snapshots =
+            generators::resolve_db_snapshots(all_nodes, &ns, &self.filesystem).await?;
+
         let base_dir = ns.base_dir().to_string_lossy();
         let scoped_fs = ScopedFilesystem::new(&self.filesystem, &base_dir);
         // Create chain-spec for relaychain
@@ -424,6 +439,7 @@ where
             wait_ready: false,
             nodes_by_name: json!({}),
             global_settings: &network_spec.global_settings,
+            resolved_db_snapshots: &resolved_db_snapshots,
         };
 
         let global_files_to_inject = vec![TransferedFile::new(
@@ -688,6 +704,8 @@ where
         if network_spec.global_settings.tear_down_on_failure() {
             network.spawn_watching_task();
         }
+
+        generators::cleanup_db_snapshot_cache(&resolved_db_snapshots).await;
 
         Ok(network)
     }

--- a/crates/orchestrator/src/network.rs
+++ b/crates/orchestrator/src/network.rs
@@ -26,7 +26,7 @@ use tracing::{error, warn};
 
 use self::{node::NetworkNode, parachain::Parachain, relaychain::Relaychain};
 use crate::{
-    generators::chain_spec::ChainSpec,
+    generators::{self, chain_spec::ChainSpec},
     network_spec::{self, NetworkSpec},
     observability::{self, ObservabilityInfo, ObservabilityState},
     shared::{
@@ -214,6 +214,13 @@ impl<T: FileSystem> Network<T> {
         let base_dir = self.ns.base_dir().to_string_lossy();
         let scoped_fs = ScopedFilesystem::new(&self.filesystem, &base_dir);
 
+        let resolved_db_snapshots = generators::resolve_db_snapshots(
+            std::iter::once(&node_spec),
+            &self.ns,
+            &self.filesystem,
+        )
+        .await?;
+
         let ctx = SpawnNodeCtx {
             chain_id: &relaychain.chain_id,
             parachain_id: None,
@@ -226,6 +233,7 @@ impl<T: FileSystem> Network<T> {
             wait_ready: true,
             nodes_by_name: serde_json::to_value(&self.nodes_by_name)?,
             global_settings: &self.initial_spec.global_settings,
+            resolved_db_snapshots: &resolved_db_snapshots,
         };
 
         let global_files_to_inject = vec![TransferedFile::new(
@@ -254,6 +262,8 @@ impl<T: FileSystem> Network<T> {
 
         // Dump zombie.json
         self.write_zombie_json().await?;
+
+        generators::cleanup_db_snapshot_cache(&resolved_db_snapshots).await;
 
         Ok(())
     }
@@ -323,21 +333,6 @@ impl<T: FileSystem> Network<T> {
         let base_dir = self.ns.base_dir().to_string_lossy();
         let scoped_fs = ScopedFilesystem::new(&self.filesystem, &base_dir);
 
-        // TODO: we want to still supporting spawn a dedicated bootnode??
-        let ctx = SpawnNodeCtx {
-            chain_id: &self.relay.chain_id,
-            parachain_id: parachain.chain_id.as_deref(),
-            chain: &self.relay.chain,
-            role,
-            ns: &self.ns,
-            scoped_fs: &scoped_fs,
-            parachain: Some(spec),
-            bootnodes_addr: &vec![],
-            wait_ready: true,
-            nodes_by_name: serde_json::to_value(&self.nodes_by_name)?,
-            global_settings: &self.initial_spec.global_settings,
-        };
-
         let relaychain_spec_path = if let Some(chain_spec_custom_path) = &options.chain_spec_relay {
             chain_spec_custom_path.clone()
         } else {
@@ -386,6 +381,29 @@ impl<T: FileSystem> Network<T> {
                 .await?,
         );
 
+        let resolved_db_snapshots = generators::resolve_db_snapshots(
+            std::iter::once(&node_spec),
+            &self.ns,
+            &self.filesystem,
+        )
+        .await?;
+
+        // TODO: we want to still supporting spawn a dedicated bootnode??
+        let ctx = SpawnNodeCtx {
+            chain_id: &self.relay.chain_id,
+            parachain_id: parachain.chain_id.as_deref(),
+            chain: &self.relay.chain,
+            role,
+            ns: &self.ns,
+            scoped_fs: &scoped_fs,
+            parachain: Some(spec),
+            bootnodes_addr: &vec![],
+            wait_ready: true,
+            nodes_by_name: serde_json::to_value(&self.nodes_by_name)?,
+            global_settings: &self.initial_spec.global_settings,
+            resolved_db_snapshots: &resolved_db_snapshots,
+        };
+
         let node = spawner::spawn_node(&node_spec, global_files_to_inject, &ctx).await?;
 
         // Let's make sure node is up before adding
@@ -396,6 +414,8 @@ impl<T: FileSystem> Network<T> {
 
         // Dump zombie.json
         self.write_zombie_json().await?;
+
+        generators::cleanup_db_snapshot_cache(&resolved_db_snapshots).await;
 
         Ok(())
     }
@@ -550,6 +570,13 @@ impl<T: FileSystem> Network<T> {
             Parachain::from_spec(&para_spec, &global_files_to_inject, &scoped_fs).await?;
         let parachain_id = parachain.chain_id.clone();
 
+        let resolved_db_snapshots = generators::resolve_db_snapshots(
+            para_spec.collators.iter(),
+            &self.ns,
+            &self.filesystem,
+        )
+        .await?;
+
         // Create `ctx` for spawn the nodes
         let ctx_para = SpawnNodeCtx {
             parachain: Some(&para_spec),
@@ -571,6 +598,7 @@ impl<T: FileSystem> Network<T> {
             wait_ready: false,
             nodes_by_name: serde_json::to_value(&self.nodes_by_name)?,
             global_settings: &self.initial_spec.global_settings,
+            resolved_db_snapshots: &resolved_db_snapshots,
         };
 
         // Register the parachain to the running network
@@ -633,6 +661,8 @@ impl<T: FileSystem> Network<T> {
 
         // Dump zombie.json
         self.write_zombie_json().await?;
+
+        generators::cleanup_db_snapshot_cache(&resolved_db_snapshots).await;
 
         Ok(())
     }

--- a/crates/orchestrator/src/spawner.rs
+++ b/crates/orchestrator/src/spawner.rs
@@ -14,7 +14,7 @@ use support::{
 use tracing::info;
 
 use crate::{
-    generators,
+    generators::{self, ResolvedDbSnapshots},
     network::{node::NetworkNode, NodeContext},
     network_spec::{node::NodeSpec, parachain::ParachainSpec},
     shared::constants::{FULL_NODE_PROMETHEUS_PORT, PROMETHEUS_PORT, RPC_PORT},
@@ -46,6 +46,11 @@ pub struct SpawnNodeCtx<'a, T: FileSystem> {
     pub(crate) nodes_by_name: serde_json::Value,
     /// A ref to the global settings
     pub(crate) global_settings: &'a GlobalSettings,
+    /// `db_snapshot` `AssetLocation`s resolved to local cache paths,
+    /// populated once before the parallel spawn fanout. The provider's
+    /// `initialize_db_snapshot` reads from these paths only — no
+    /// downloads happen inside the per-node spawn.
+    pub(crate) resolved_db_snapshots: &'a ResolvedDbSnapshots,
 }
 
 pub async fn spawn_node<'a, T>(
@@ -188,6 +193,22 @@ where
         ]
     };
 
+    let resolved_db_snapshot = node
+        .db_snapshot
+        .as_ref()
+        .and_then(|loc| ctx.resolved_db_snapshots.get(loc).cloned());
+    if node.db_snapshot.is_some() && resolved_db_snapshot.is_none() {
+        // Invariant: every NodeSpec.db_snapshot must have been resolved
+        // by orchestrator::generators::resolve_db_snapshots before we
+        // get here. Hitting this path means the resolution step was
+        // skipped for this node.
+        return Err(anyhow::anyhow!(
+            "{THIS_IS_A_BUG}: node {} has db_snapshot {:?} but no resolved cache entry",
+            node.name,
+            node.db_snapshot,
+        ));
+    }
+
     let spawn_ops = SpawnNodeOptions::new(node.name.clone(), program)
         .args(args)
         .env(
@@ -197,7 +218,7 @@ where
         )
         .injected_files(files_to_inject)
         .created_paths(created_paths)
-        .db_snapshot(node.db_snapshot.clone())
+        .db_snapshot(resolved_db_snapshot)
         .port_mapping(HashMap::from(ports))
         .node_log_path(node.node_log_path.clone());
 

--- a/crates/provider/src/docker/namespace.rs
+++ b/crates/provider/src/docker/namespace.rs
@@ -343,7 +343,7 @@ where
             args: &options.args,
             env: &options.env,
             startup_files: &options.injected_files,
-            db_snapshot: options.db_snapshot.as_ref(),
+            db_snapshot: options.db_snapshot.as_deref(),
             docker_client: &self.docker_client,
             container_name: format!("{}-{}", self.name, options.name),
             filesystem: &self.filesystem,

--- a/crates/provider/src/docker/node.rs
+++ b/crates/provider/src/docker/node.rs
@@ -38,7 +38,7 @@ where
     pub(super) args: &'a [String],
     pub(super) env: &'a [(String, String)],
     pub(super) startup_files: &'a [TransferedFile],
-    pub(super) db_snapshot: Option<&'a AssetLocation>,
+    pub(super) db_snapshot: Option<&'a Path>,
     pub(super) docker_client: &'a DockerClient,
     pub(super) container_name: String,
     pub(super) filesystem: &'a FS,
@@ -271,8 +271,8 @@ where
         Ok(())
     }
 
-    fn build_db_snapshot_command(download_url: Option<&str>) -> RunCommandOptions {
-        let mut args = vec![
+    fn build_db_snapshot_command() -> RunCommandOptions {
+        let args = vec![
             "-p".to_string(),
             "/data/".to_string(),
             "&&".to_string(),
@@ -280,19 +280,6 @@ where
             "-p".to_string(),
             "/relay-data/".to_string(),
             "&&".to_string(),
-        ];
-
-        if let Some(url) = download_url {
-            args.extend([
-                "/helpers/curl".to_string(),
-                url.to_string(),
-                "--output".to_string(),
-                "/data/db.tgz".to_string(),
-                "&&".to_string(),
-            ]);
-        }
-
-        args.extend([
             "cd".to_string(),
             "/".to_string(),
             "&&".to_string(),
@@ -300,47 +287,22 @@ where
             "--skip-old-files".to_string(),
             "-xzvf".to_string(),
             "/data/db.tgz".to_string(),
-        ]);
+        ];
 
         RunCommandOptions::new("mkdir").args(args)
     }
 
-    async fn initialize_db_snapshot(
-        &self,
-        db_snapshot: &AssetLocation,
-    ) -> Result<(), ProviderError> {
+    async fn initialize_db_snapshot(&self, db_snapshot: &Path) -> Result<(), ProviderError> {
         trace!(
-            "initializing docker db snapshot for node {}: {db_snapshot}",
-            self.name
+            "initializing docker db snapshot for node {} from {}",
+            self.name,
+            db_snapshot.display()
         );
 
-        match db_snapshot {
-            AssetLocation::Url(url) => {
-                let url_of_snap = url.to_string();
-                trace!(
-                    "downloading snapshot for node {} from {}",
-                    self.name,
-                    url_of_snap
-                );
+        self.send_file(db_snapshot, Path::new("/data/db.tgz"), "0644")
+            .await?;
 
-                let opts = Self::build_db_snapshot_command(Some(&url_of_snap));
-                let _ = self.run_command(opts).await?;
-            },
-            AssetLocation::FilePath(path) => {
-                trace!(
-                    "uploading local snapshot {} into container {}",
-                    path.to_string_lossy(),
-                    self.container_name
-                );
-
-                self.send_file(path.as_path(), Path::new("/data/db.tgz"), "0644")
-                    .await?;
-
-                let opts = Self::build_db_snapshot_command(None);
-                let _ = self.run_command(opts).await?;
-            },
-        }
-
+        let _ = self.run_command(Self::build_db_snapshot_command()).await?;
         Ok(())
     }
 

--- a/crates/provider/src/kubernetes/namespace.rs
+++ b/crates/provider/src/kubernetes/namespace.rs
@@ -490,7 +490,7 @@ where
             env: &options.env,
             startup_files: &options.injected_files,
             resources: options.resources.as_ref(),
-            db_snapshot: options.db_snapshot.as_ref(),
+            db_snapshot: options.db_snapshot.as_deref(),
             k8s_client: &self.k8s_client,
             filesystem: &self.filesystem,
         })

--- a/crates/provider/src/kubernetes/node.rs
+++ b/crates/provider/src/kubernetes/node.rs
@@ -45,7 +45,7 @@ where
     pub(super) env: &'a [(String, String)],
     pub(super) startup_files: &'a [TransferedFile],
     pub(super) resources: Option<&'a Resources>,
-    pub(super) db_snapshot: Option<&'a AssetLocation>,
+    pub(super) db_snapshot: Option<&'a Path>,
     pub(super) k8s_client: &'a KubernetesClient,
     pub(super) filesystem: &'a FS,
 }
@@ -319,18 +319,12 @@ where
         Ok(())
     }
 
-    async fn initialize_db_snapshot(
-        &self,
-        db_snapshot: &AssetLocation,
-    ) -> Result<(), ProviderError> {
-        trace!("snap: {db_snapshot}");
-        let url_of_snap = match db_snapshot {
-            AssetLocation::Url(location) => location.clone(),
-            AssetLocation::FilePath(filepath) => {
-                let (url, _) = self.upload_to_fileserver(filepath).await?;
-                url
-            },
-        };
+    async fn initialize_db_snapshot(&self, db_snapshot: &Path) -> Result<(), ProviderError> {
+        trace!("snap: {}", db_snapshot.display());
+        // The orchestrator already downloaded/copied the snapshot into
+        // the namespace cache; we still need the pod to fetch it over
+        // HTTP, so upload to the fileserver and curl from inside.
+        let (url_of_snap, _) = self.upload_to_fileserver(db_snapshot).await?;
 
         // we need to get the snapshot from a public access
         // and extract to /data

--- a/crates/provider/src/native/namespace.rs
+++ b/crates/provider/src/native/namespace.rs
@@ -160,7 +160,7 @@ where
             env: &options.env,
             startup_files: &options.injected_files,
             created_paths: &options.created_paths,
-            db_snapshot: options.db_snapshot.as_ref(),
+            db_snapshot: options.db_snapshot.as_deref(),
             filesystem: &self.filesystem,
             node_log_path: options.node_log_path.as_ref(),
         })

--- a/crates/provider/src/native/node.rs
+++ b/crates/provider/src/native/node.rs
@@ -445,7 +445,6 @@ where
 
         Ok(())
     }
-
 }
 
 #[async_trait]

--- a/crates/provider/src/native/node.rs
+++ b/crates/provider/src/native/node.rs
@@ -17,11 +17,9 @@ use nix::{
     unistd::Pid,
 };
 use serde::{ser::Error, Deserialize, Serialize, Serializer};
-use sha2::Digest;
 use support::{constants::THIS_IS_A_BUG, fs::FileSystem};
 use tar::Archive;
 use tokio::{
-    fs,
     io::{AsyncRead, AsyncReadExt, BufReader},
     process::{Child, ChildStderr, ChildStdout, Command},
     sync::{
@@ -39,7 +37,7 @@ use crate::{
     constants::{NODE_CONFIG_DIR, NODE_DATA_DIR, NODE_RELAY_DATA_DIR, NODE_SCRIPTS_DIR},
     native,
     types::{ExecutionResult, RunCommandOptions, RunScriptOptions, TransferedFile},
-    ProviderError, ProviderNamespace, ProviderNode,
+    ProviderError, ProviderNode,
 };
 
 pub(super) struct NativeNodeOptions<'a, FS>
@@ -54,7 +52,7 @@ where
     pub(super) env: &'a [(String, String)],
     pub(super) startup_files: &'a [TransferedFile],
     pub(super) created_paths: &'a [PathBuf],
-    pub(super) db_snapshot: Option<&'a AssetLocation>,
+    pub(super) db_snapshot: Option<&'a Path>,
     pub(super) filesystem: &'a FS,
     pub(super) node_log_path: Option<&'a PathBuf>,
 }
@@ -275,64 +273,23 @@ where
         Ok(())
     }
 
-    async fn initialize_db_snapshot(
-        &self,
-        db_snapshot: &AssetLocation,
-    ) -> Result<(), ProviderError> {
-        trace!("snap: {db_snapshot}");
-
-        // check if we need to get the db or is already in the ns
-        let ns_base_dir = self.namespace_base_dir();
-        let hashed_location = match db_snapshot {
-            AssetLocation::Url(location) => hex::encode(sha2::Sha256::digest(location.to_string())),
-            AssetLocation::FilePath(filepath) => {
-                hex::encode(sha2::Sha256::digest(filepath.to_string_lossy().to_string()))
-            },
-        };
-
-        let full_path = format!("{ns_base_dir}/{hashed_location}.tgz");
-        trace!("db_snap fullpath in ns: {full_path}");
-        if !self.filesystem.exists(&full_path).await {
-            // needs to download/copy
-            self.get_db_snapshot(db_snapshot, &full_path).await?;
-        }
-
-        let contents = self.filesystem.read(&full_path).await.unwrap();
+    async fn initialize_db_snapshot(&self, db_snapshot: &Path) -> Result<(), ProviderError> {
+        trace!(
+            "extracting db_snapshot {} -> {}",
+            db_snapshot.display(),
+            self.base_dir.display()
+        );
+        let contents = self.filesystem.read(db_snapshot).await?;
         let gz = GzDecoder::new(&contents[..]);
         let mut archive = Archive::new(gz);
         archive
             .unpack(self.base_dir.to_string_lossy().as_ref())
-            .unwrap();
-
-        if std::env::var("ZOMBIE_RM_TGZ_AFTER_EXTRACT").is_ok() {
-            let res = fs::remove_file(&full_path).await;
-            trace!("removing {}, result {:?}", full_path, res);
-        }
-
-        Ok(())
-    }
-
-    async fn get_db_snapshot(
-        &self,
-        location: &AssetLocation,
-        full_path: &str,
-    ) -> Result<(), ProviderError> {
-        trace!("getting db_snapshot from: {:?} to: {full_path}", location);
-        match location {
-            AssetLocation::Url(location) => {
-                let res = reqwest::get(location.as_ref())
-                    .await
-                    .map_err(|err| ProviderError::DownloadFile(location.to_string(), err.into()))?;
-
-                let contents: &[u8] = &res.bytes().await.unwrap();
-                trace!("writing: {full_path}");
-                self.filesystem.write(full_path, contents).await?;
-            },
-            AssetLocation::FilePath(filepath) => {
-                self.filesystem.copy(filepath, full_path).await?;
-            },
-        };
-
+            .map_err(|err| {
+                ProviderError::FileGenerationFailed(anyhow!(
+                    "failed to extract db_snapshot {}: {err}",
+                    db_snapshot.display()
+                ))
+            })?;
         Ok(())
     }
 
@@ -489,12 +446,6 @@ where
         Ok(())
     }
 
-    fn namespace_base_dir(&self) -> String {
-        self.namespace
-            .upgrade()
-            .map(|namespace| namespace.base_dir().to_string_lossy().to_string())
-            .unwrap_or_else(|| panic!("namespace shouldn't be dropped, {THIS_IS_A_BUG}"))
-    }
 }
 
 #[async_trait]

--- a/crates/provider/src/shared/types.rs
+++ b/crates/provider/src/shared/types.rs
@@ -4,7 +4,7 @@ use std::{
     process::ExitStatus,
 };
 
-use configuration::{shared::resources::Resources, types::AssetLocation};
+use configuration::shared::resources::Resources;
 use serde::{Deserialize, Serialize};
 
 pub type Port = u16;
@@ -46,9 +46,10 @@ pub struct SpawnNodeOptions {
     /// should be created with `create_dir_all` in order
     /// to create the full path even when we have missing parts
     pub created_paths: Vec<PathBuf>,
-    /// Database snapshot to be injected (should be a tgz file)
-    /// Could be a local or remote asset
-    pub db_snapshot: Option<AssetLocation>,
+    /// Database snapshot to be injected (a local `.tgz` resolved by the
+    /// orchestrator before spawn — providers extract it directly, no
+    /// download). See `orchestrator::generators::resolve_db_snapshots`.
+    pub db_snapshot: Option<PathBuf>,
     pub port_mapping: Option<HashMap<Port, Port>>,
     /// Optionally specify a log path for the node
     pub node_log_path: Option<PathBuf>,
@@ -87,7 +88,7 @@ impl SpawnNodeOptions {
         self
     }
 
-    pub fn db_snapshot(mut self, db_snap: Option<AssetLocation>) -> Self {
+    pub fn db_snapshot(mut self, db_snap: Option<PathBuf>) -> Self {
         self.db_snapshot = db_snap;
         self
     }


### PR DESCRIPTION
There is a race condition in initialize_db_snapshot when a db_snapshot `AssetLocation` is shared across multiple sibling nodes. Each spawned node independently downloads/copies the asset into the namespace cache at `{ns_base_dir}/{sha256(loc)}.tgz`. This happens to be executed in parallel.

 The current workaround in downstream tests (e.g. smoldot [`smoke_generate_snapshots.rs`](https://github.com/paritytech/smoldot/blame/7fbf4e0e898d235a2c25cf4b0f5cd74cbac6e45b/e2e-tests/tests/smoke_generate_snapshots.rs#L75-L83)) is to pre-stage per-node copies under unique filenames so the cache keys don't collide.

This PR fixes it by moving asset resolution upstream of the parallel fanout:
  - New `orchestrator::generators::resolve_db_snapshots` walks every `NodeSpec::db_snapshot`, deduplicates by `AssetLocation`, and serially populates the cache. Runs once in `Orchestrator::spawn_inner` (and once per `Network::add_node / add_collator / add_parachain`) before any node  spawns.
  - `SpawnNodeOptions::db_snapshot` flips from `Option<AssetLocation>` to `Option<PathBuf>` - the resolved cache path. Each provider's `initialize_db_snapshot` now takes a `&Path` and only extracts; no downloads, no exists() check, no race.
  - `ZOMBIE_RM_TGZ_AFTER_EXTRACT` cleanup moves from the per-node code path (would delete the cache while sibling nodes are still reading it) to `cleanup_db_snapshot_cache`, called after all consumers finish.

 Public SDK API (`with_db_snapshot`, `AssetLocation`, etc.) is unchanged.