### PR TITLE
Correct the Core Count Check

### DIFF
--- a/crates/orchestrator/src/generators/session_0_overrides.rs
+++ b/crates/orchestrator/src/generators/session_0_overrides.rs
@@ -111,7 +111,7 @@ pub fn generate_session_0_overrides(
 
     // some checks first
     if num_genesis_cores > session.validators.len() as u32 {
-        return Err(GeneratorError::InvariantError(format!("Num cores in genesis {num_genesis_cores} should be less than the num of validators ({})", session.validators.len())));
+        return Err(GeneratorError::InvariantError(format!("Num cores in genesis {num_genesis_cores} should be less than or equal to the num of validators ({})", session.validators.len())));
     }
 
     let groups = genetate_groups(session.validators.len() as u32, num_genesis_cores);

--- a/crates/orchestrator/src/generators/session_0_overrides.rs
+++ b/crates/orchestrator/src/generators/session_0_overrides.rs
@@ -110,7 +110,7 @@ pub fn generate_session_0_overrides(
     // generate validator groups
 
     // some checks first
-    if num_genesis_cores >= session.validators.len() as u32 {
+    if num_genesis_cores > session.validators.len() as u32 {
         return Err(GeneratorError::InvariantError(format!("Num cores in genesis {num_genesis_cores} should be less than the num of validators ({})", session.validators.len())));
     }
 


### PR DESCRIPTION
# Description

This is a small PR which corrects the core count & validator count checks we have. We used to require that we have more validators than cores which I think is the wrong check to have, we need to check that we have as many validators as cores (or more).

This has been tested with retester to make sure that networks can be spawned (and operate correctly) when validators = number of cores and networks operate correctly.