### PR TITLE
Use export-chain-spec as the default chain-spec command

### DIFF
--- a/crates/orchestrator/src/shared/constants.rs
+++ b/crates/orchestrator/src/shared/constants.rs
@@ -8,9 +8,11 @@ pub const RPC_PORT: u16 = 9944;
 pub const RPC_HTTP_PORT: u16 = 9933;
 // P2P default port
 pub const P2P_PORT: u16 = 30333;
-// default command template to build chain-spec
+// Default command template to export a chain-spec.
+// `export-chain-spec` replaced the deprecated `build-spec` CLI in polkadot-sdk.
+// Bootnodes are customized after generation, so `--disable-default-bootnode` is unused.
 pub const DEFAULT_CHAIN_SPEC_TPL_COMMAND: &str =
-    "{{mainCommand}} build-spec --chain {{chainName}} {{disableBootnodes}}";
+    "{{mainCommand}} export-chain-spec --chain {{chainName}}";
 // interval to determine how often to run node liveness checks
 pub const NODE_MONITORING_INTERVAL_SECONDS: u64 = 15;
 // how long to wait before a node is considered unresponsive

--- a/crates/orchestrator/src/shared/constants.rs
+++ b/crates/orchestrator/src/shared/constants.rs
@@ -9,8 +9,6 @@ pub const RPC_HTTP_PORT: u16 = 9933;
 // P2P default port
 pub const P2P_PORT: u16 = 30333;
 // Default command template to export a chain-spec.
-// `export-chain-spec` replaced the deprecated `build-spec` CLI in polkadot-sdk.
-// Bootnodes are customized after generation, so `--disable-default-bootnode` is unused.
 pub const DEFAULT_CHAIN_SPEC_TPL_COMMAND: &str =
     "{{mainCommand}} export-chain-spec --chain {{chainName}}";
 // interval to determine how often to run node liveness checks


### PR DESCRIPTION
## Summary
- Change `DEFAULT_CHAIN_SPEC_TPL_COMMAND` from deprecated `build-spec` to `export-chain-spec`
- Drop `--disable-default-bootnode` from the default template (`export-chain-spec` does not support it; zombienet still customizes bootnodes after generation)

Needed so polkadot-sdk can remove `build-spec` without every test overriding `chain_spec_command` (see paritytech/polkadot-sdk#12586).

## Test plan
- [ ] Existing zombienet-sdk CI passes
- [ ] Spawning a network without a custom `chain_spec_command` runs `<binary> export-chain-spec --chain <name>`