### PR TITLE
add logic to use export-chain-spec or build-spec as subcommand

### DIFF
--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -154,15 +154,27 @@ impl ChainSpec {
                 .first()
                 .expect("main_cmd should be preset to build the expect. qed");
             debug!("resolving subcommand for: {main_cmd}");
-            let help_output = ns
-                .get_node_available_args((main_cmd.to_string(), self.image.clone()))
-                .await?;
-
-            self.subcommand = if help_output.contains("export-chain-spec") {
-                Some("export-chain-spec".to_string())
-            } else {
-                Some("build-spec".to_string())
+            let chain_name_is_empty = match self.chain_name() {
+                None => true,
+                Some(chain) => chain.is_empty(),
             };
+
+            // IFF cmd is polkadot-parachain and chain is empty
+            // we should always use `build-spec`
+            if *main_cmd == "polkadot-parachain" && chain_name_is_empty {
+                self.subcommand = Some("build-spec".to_string())
+            } else {
+                // we should run to check the output
+                let help_output = ns
+                    .get_node_available_args((main_cmd.to_string(), self.image.clone()))
+                    .await?;
+
+                self.subcommand = if help_output.contains("export-chain-spec") {
+                    Some("export-chain-spec".to_string())
+                } else {
+                    Some("build-spec".to_string())
+                };
+            }
         }
 
         Ok(())

--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -320,11 +320,35 @@ impl ChainSpec {
                 self.command.as_ref().unwrap().cmd().to_owned()
             };
 
-            let full_cmd = apply_replacements(
-                &sanitized_cmd,
-                &HashMap::from([("chainName", replacement_value.as_str())]),
-            );
-            trace!("full_cmd: {:?}", full_cmd);
+            let main_cmd_parts: Vec<&str> = sanitized_cmd.split_whitespace().collect();
+            let main_cmd = main_cmd_parts
+                .first()
+                .expect("main_cmd should be preset to build the expect. qed");
+            debug!("resolving subcommand for: {main_cmd}");
+            let use_export_chain_spec =
+                if *main_cmd == "polkadot-parachain" && replacement_value.is_empty() {
+                    false
+                } else {
+                    let help_output = ns
+                        .get_node_available_args((main_cmd.to_string(), self.image.clone()))
+                        .await?;
+                    help_output.contains("export-chain-spec")
+                };
+
+            let mut replacements = HashMap::from([("chainName", replacement_value.as_str())]);
+
+            if use_export_chain_spec {
+                replacements.insert("subCommand", "export-chain-spec");
+                replacements.insert("disableBootnodes", "");
+            } else {
+                // use build-spec
+                replacements.insert("subCommand", "build-spec");
+                replacements.insert("disableBootnodes", "--disable-default-bootnode");
+            }
+
+            let full_cmd = apply_replacements(&sanitized_cmd, &replacements);
+
+            debug!("full_cmd: {:?}", full_cmd);
 
             let parts: Vec<&str> = full_cmd.split_whitespace().collect();
             let Some((cmd, args)) = parts.split_first() else {

--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -115,6 +115,8 @@ pub struct ChainSpec {
     raw_path: Option<PathBuf>,
     // The binary to build the chain-spec
     command: Option<CommandInContext>,
+    // The subcommand to exec e.g. `export-chain-spec`
+    subcommand: Option<String>,
     // Imgae to use for build the chain-spec
     image: Option<String>,
     // Contex of the network (e.g relay or para)
@@ -131,9 +133,33 @@ impl ChainSpec {
             runtime: None,
             raw_path: None,
             command: None,
+            subcommand: None,
             image: None,
             context,
         }
+    }
+
+    async fn resolve_subcommand(&mut self, ns: &DynNamespace) -> Result<(), GeneratorError> {
+        if self.subcommand.is_none() {
+            // SAFETY: we ensure that command is some with the first check of the fn
+            // default as empty
+            let main_cmd_parts: Vec<&str> = self.command.as_ref().unwrap().cmd().split_whitespace().collect();
+            let main_cmd = main_cmd_parts
+                .first()
+                .expect("main_cmd should be preset to build the expect. qed");
+            debug!("resolving subcommand for: {main_cmd}");
+            let help_output = ns
+                .get_node_available_args((main_cmd.to_string(), self.image.clone()))
+                .await?;
+
+            self.subcommand = if help_output.contains("export-chain-spec") {
+                Some("export-chain-spec".to_string())
+            } else {
+                Some("build-spec".to_string())
+            };
+        }
+
+        Ok(())
     }
 
     pub(crate) fn chain_spec_name(&self) -> &str {
@@ -320,24 +346,11 @@ impl ChainSpec {
                 self.command.as_ref().unwrap().cmd().to_owned()
             };
 
-            let main_cmd_parts: Vec<&str> = sanitized_cmd.split_whitespace().collect();
-            let main_cmd = main_cmd_parts
-                .first()
-                .expect("main_cmd should be preset to build the expect. qed");
-            debug!("resolving subcommand for: {main_cmd}");
-            let use_export_chain_spec =
-                if *main_cmd == "polkadot-parachain" && replacement_value.is_empty() {
-                    false
-                } else {
-                    let help_output = ns
-                        .get_node_available_args((main_cmd.to_string(), self.image.clone()))
-                        .await?;
-                    help_output.contains("export-chain-spec")
-                };
+            self.resolve_subcommand(ns).await?;
 
             let mut replacements = HashMap::from([("chainName", replacement_value.as_str())]);
 
-            if use_export_chain_spec {
+            if self.subcommand.as_deref() == Some("export-chain-spec")  {
                 replacements.insert("subCommand", "export-chain-spec");
                 replacements.insert("disableBootnodes", "");
             } else {
@@ -487,6 +500,8 @@ impl ChainSpec {
             rand::random::<u8>()
         );
 
+        self.resolve_subcommand(ns).await?;
+
         let cmd = self
             .command
             .as_ref()
@@ -524,9 +539,21 @@ impl ChainSpec {
             chain_spec_path_in_pod.clone()
         };
 
+
+            let mut replacements = HashMap::from([("chainName", chain_spec_path_in_args.as_str())]);
+
+            if self.subcommand.as_deref() == Some("export-chain-spec")  {
+                replacements.insert("subCommand", "export-chain-spec");
+                replacements.insert("disableBootnodes", "");
+            } else {
+                // use build-spec
+                replacements.insert("subCommand", "build-spec");
+                replacements.insert("disableBootnodes", "--disable-default-bootnode");
+            }
+
         let mut full_cmd = apply_replacements(
             cmd.cmd(),
-            &HashMap::from([("chainName", chain_spec_path_in_args.as_str())]),
+            &replacements
         );
 
         if !full_cmd.contains("--raw") {

--- a/crates/orchestrator/src/generators/chain_spec.rs
+++ b/crates/orchestrator/src/generators/chain_spec.rs
@@ -143,7 +143,13 @@ impl ChainSpec {
         if self.subcommand.is_none() {
             // SAFETY: we ensure that command is some with the first check of the fn
             // default as empty
-            let main_cmd_parts: Vec<&str> = self.command.as_ref().unwrap().cmd().split_whitespace().collect();
+            let main_cmd_parts: Vec<&str> = self
+                .command
+                .as_ref()
+                .unwrap()
+                .cmd()
+                .split_whitespace()
+                .collect();
             let main_cmd = main_cmd_parts
                 .first()
                 .expect("main_cmd should be preset to build the expect. qed");
@@ -350,7 +356,7 @@ impl ChainSpec {
 
             let mut replacements = HashMap::from([("chainName", replacement_value.as_str())]);
 
-            if self.subcommand.as_deref() == Some("export-chain-spec")  {
+            if self.subcommand.as_deref() == Some("export-chain-spec") {
                 replacements.insert("subCommand", "export-chain-spec");
                 replacements.insert("disableBootnodes", "");
             } else {
@@ -539,22 +545,18 @@ impl ChainSpec {
             chain_spec_path_in_pod.clone()
         };
 
+        let mut replacements = HashMap::from([("chainName", chain_spec_path_in_args.as_str())]);
 
-            let mut replacements = HashMap::from([("chainName", chain_spec_path_in_args.as_str())]);
+        if self.subcommand.as_deref() == Some("export-chain-spec") {
+            replacements.insert("subCommand", "export-chain-spec");
+            replacements.insert("disableBootnodes", "");
+        } else {
+            // use build-spec
+            replacements.insert("subCommand", "build-spec");
+            replacements.insert("disableBootnodes", "--disable-default-bootnode");
+        }
 
-            if self.subcommand.as_deref() == Some("export-chain-spec")  {
-                replacements.insert("subCommand", "export-chain-spec");
-                replacements.insert("disableBootnodes", "");
-            } else {
-                // use build-spec
-                replacements.insert("subCommand", "build-spec");
-                replacements.insert("disableBootnodes", "--disable-default-bootnode");
-            }
-
-        let mut full_cmd = apply_replacements(
-            cmd.cmd(),
-            &replacements
-        );
+        let mut full_cmd = apply_replacements(cmd.cmd(), &replacements);
 
         if !full_cmd.contains("--raw") {
             full_cmd = format!("{full_cmd} --raw");

--- a/crates/orchestrator/src/network_spec/parachain.rs
+++ b/crates/orchestrator/src/network_spec/parachain.rs
@@ -157,10 +157,7 @@ impl ParachainSpec {
             };
             let chain_spec_builder = chain_spec_builder.set_chain_name(chain_name);
 
-            let replacements = HashMap::from([
-                ("disableBootnodes", "--disable-default-bootnode"),
-                ("mainCommand", main_cmd.as_str()),
-            ]);
+            let replacements = HashMap::from([("mainCommand", main_cmd.as_str())]);
             let tmpl = if let Some(tmpl) = config.chain_spec_command() {
                 apply_replacements(tmpl, &replacements)
             } else {

--- a/crates/orchestrator/src/network_spec/relaychain.rs
+++ b/crates/orchestrator/src/network_spec/relaychain.rs
@@ -89,10 +89,7 @@ impl RelaychainSpec {
             .or(config.nodes().first().and_then(|node| node.image()))
             .map(|image| image.as_str().to_string());
 
-        let replacements = HashMap::from([
-            ("disableBootnodes", "--disable-default-bootnode"),
-            ("mainCommand", main_cmd.as_str()),
-        ]);
+        let replacements = HashMap::from([("mainCommand", main_cmd.as_str())]);
         let tmpl = if let Some(tmpl) = config.chain_spec_command() {
             apply_replacements(tmpl, &replacements)
         } else {

--- a/crates/orchestrator/src/shared/constants.rs
+++ b/crates/orchestrator/src/shared/constants.rs
@@ -10,7 +10,7 @@ pub const RPC_HTTP_PORT: u16 = 9933;
 pub const P2P_PORT: u16 = 30333;
 // default command template to build chain-spec
 pub const DEFAULT_CHAIN_SPEC_TPL_COMMAND: &str =
-    "{{mainCommand}} build-spec --chain {{chainName}} {{disableBootnodes}}";
+    "{{mainCommand}} {{subCommand}} --chain {{chainName}} {{disableBootnodes}}";
 // interval to determine how often to run node liveness checks
 pub const NODE_MONITORING_INTERVAL_SECONDS: u64 = 15;
 // how long to wait before a node is considered unresponsive


### PR DESCRIPTION
replace #557, add logic to use `export-chain-spec` when is present and fallback to `build-spec` for old nodes.

cc: @bkontur / @Kanasjnr