### PR TITLE
specify https in wget calls in helper-binaries-downloader script

### DIFF
--- a/crates/provider/src/shared/scripts/helper-binaries-downloader.sh
+++ b/crates/provider/src/shared/scripts/helper-binaries-downloader.sh
@@ -15,7 +15,7 @@ if [ -f /tmp/curl ]; then
     cp /tmp/curl $OUTDIR/curl
     log "curl copied"
 else
-    wget github.com/moparisthebest/static-curl/releases/download/v7.83.1/curl-amd64 -O "$OUTDIR/curl"
+    wget https://github.com/moparisthebest/static-curl/releases/download/v7.83.1/curl-amd64 -O "$OUTDIR/curl"
     log "curl downloaded"
 fi;
 
@@ -26,7 +26,7 @@ if [ -f /tmp/coreutils ]; then
     cp /tmp/coreutils $OUTDIR/coreutils
     log "coreutils copied"
 else
-    wget -qO- github.com/uutils/coreutils/releases/download/0.0.17/coreutils-0.0.17-x86_64-unknown-linux-musl.tar.gz | tar -xz -C $OUTDIR --strip-components=1 coreutils-0.0.17-x86_64-unknown-linux-musl/coreutils
+    wget -qO- https://github.com/uutils/coreutils/releases/download/0.0.17/coreutils-0.0.17-x86_64-unknown-linux-musl.tar.gz | tar -xz -C $OUTDIR --strip-components=1 coreutils-0.0.17-x86_64-unknown-linux-musl/coreutils
     log "coreutils downloaded"
 fi;
 


### PR DESCRIPTION
`wget` calls in the [helper-binaries-downloader.sh](https://github.com/paritytech/zombienet-sdk/blob/main/crates/provider/src/shared/scripts/helper-binaries-downloader.sh) script to download `curl` and `coreutils` were timing out (in docker mode, at least).

If we specify the `https://` prefix in these calls, then the downloads work. This PR adds that to the script