### PR TITLE
bump version to release `v0.4.17`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10914,7 +10914,7 @@ dependencies = [
 
 [[package]]
 name = "zombie-cli"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "anyhow",
  "clap",
@@ -10926,7 +10926,7 @@ dependencies = [
 
 [[package]]
 name = "zombie-tui"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "anyhow",
  "clap",
@@ -10950,7 +10950,7 @@ dependencies = [
 
 [[package]]
 name = "zombienet-configuration"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -10969,7 +10969,7 @@ dependencies = [
 
 [[package]]
 name = "zombienet-file-server"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "axum",
  "axum-extra",
@@ -10984,7 +10984,7 @@ dependencies = [
 
 [[package]]
 name = "zombienet-orchestrator"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "anyhow",
  "array-bytes",
@@ -11023,7 +11023,7 @@ dependencies = [
 
 [[package]]
 name = "zombienet-prom-metrics-parser"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "pest",
  "pest_derive",
@@ -11032,7 +11032,7 @@ dependencies = [
 
 [[package]]
 name = "zombienet-provider"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11062,7 +11062,7 @@ dependencies = [
 
 [[package]]
 name = "zombienet-sdk"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11091,7 +11091,7 @@ dependencies = [
 
 [[package]]
 name = "zombienet-support"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ default-members = [
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.4.16"
+version = "0.4.17"
 rust-version = "1.79.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/zombienet-sdk"
@@ -88,9 +88,9 @@ codec = { package = "parity-scale-codec", version = "3.6.12", default-features =
 socket2 = "0.6.5"
 
 # Zombienet workspace crates:
-support = { package = "zombienet-support", version = "0.4.16", path = "crates/support" }
-configuration = { package = "zombienet-configuration", version = "0.4.16", path = "crates/configuration" }
-orchestrator = { package = "zombienet-orchestrator", version = "0.4.16", path = "crates/orchestrator" }
-provider = { package = "zombienet-provider", version = "0.4.16", path = "crates/provider" }
-prom-metrics-parser = { package = "zombienet-prom-metrics-parser", version = "0.4.16", path = "crates/prom-metrics-parser" }
-zombienet-sdk = { version = "0.4.16", path = "crates/sdk" }
+support = { package = "zombienet-support", version = "0.4.17", path = "crates/support" }
+configuration = { package = "zombienet-configuration", version = "0.4.17", path = "crates/configuration" }
+orchestrator = { package = "zombienet-orchestrator", version = "0.4.17", path = "crates/orchestrator" }
+provider = { package = "zombienet-provider", version = "0.4.17", path = "crates/provider" }
+prom-metrics-parser = { package = "zombienet-prom-metrics-parser", version = "0.4.17", path = "crates/prom-metrics-parser" }
+zombienet-sdk = { version = "0.4.17", path = "crates/sdk" }


### PR DESCRIPTION
- Include fix for chain-spec generation with `test-parachain` bin.